### PR TITLE
seo(AP-07): neue Seite /x-zeit/ zum zeitversetzten Üben

### DIFF
--- a/scripts/site-pages.mjs
+++ b/scripts/site-pages.mjs
@@ -792,6 +792,33 @@ export const SITE_PAGES = [
         ]
     },
     {
+        slug: "x-zeit", source: "pages/x-zeit.html", sources: ["src/pages/x-zeit.html"],
+        kurzGesagt: "X-Zeit ist eine relative Zeitangabe ab Übungsbeginn: X+15 heißt fünfzehn Minuten nach dem Start. Der Übungsgenerator legt im X-Zeit-Modus jede Nachricht auf einen solchen Slot, berechnet aus Start-Offset und Intervall. Die Funkstellen sehen einen Countdown bis zur nächsten fälligen Nachricht, die Übungsleitung den Vergleich von Soll und Ist. Das Intervall gilt für die ganze Übung, nicht für die einzelne Funkstelle.",
+        related: ["regiebuch-funkuebung", "funkuebung-planen", "digitale-funkuebung"],
+        label: "X-Zeit",
+        hubCategory: "uebungen",
+        schemaType: "Article", datePublished: "2026-08-04",
+        about: ["X-Zeit", "Übungszeitplan", "Funkübung"],
+        faq: [
+            {
+                q: "Was bedeutet X-Zeit im Sprechfunk?",
+                a: "Eine relative Zeitangabe ab einem Bezugszeitpunkt, der beim Planen noch offen ist. X+15 bedeutet fünfzehn Minuten nach dem festgelegten Beginn. Verschiebt sich der Start, verschiebt sich der ganze Plan mit."
+            },
+            {
+                q: "Wie berechnet der Generator die X-Zeiten?",
+                a: "Nach der Formel Start-Offset plus Position mal Intervall. Die Position zählt über die ganze Übung, nicht je Funkstelle; die Anmeldungs-Funksprüche liegen alle auf X+0."
+            },
+            {
+                q: "Welches Intervall ist für einen Dienstabend sinnvoll?",
+                a: "Es ergibt sich aus dem Zeitrahmen geteilt durch die Zahl der Nachrichten. Bei acht Funkstellen mit je sechs Sprüchen und 90 Minuten Rahmen sind das etwa 2 Minuten. Unter einer Minute entstehen Wartezeiten, weil ein Verkehr 45 bis 90 Sekunden braucht."
+            },
+            {
+                q: "Sehen die Teilnehmer alle Nachrichten im Voraus?",
+                a: "Im Fokus-Modus nicht. Er zeigt allein die aktuell fällige Nachricht und hält künftige Texte bis zu ihrer Fälligkeit verborgen. Ohne Fokus-Modus bleibt die vollständige Tabelle sichtbar."
+            }
+        ]
+    },
+    {
         slug: "wissen", source: "pages/wissen.html", sources: ["src/pages/wissen.html"],
         kurzGesagt: "Sprechfunk lernt man im Lehrgang und behält es durch regelmäßiges Üben. Diese Übersicht bündelt beides: die fachlichen Grundlagen des BOS-Sprechfunks und die praktische Arbeit mit Funkübungen. Die Betriebsabwicklung folgt organisationsübergreifend der PDV/DV 810.3. Für die Praxis erzeugt der Generator vollständige Übungen.",
         related: ["funkuebung-planen", "sprechfunk-regeln", "funksprueche"],

--- a/seo/content-quality-report.md
+++ b/seo/content-quality-report.md
@@ -17,7 +17,7 @@ Inhaltsverzeichnis, Metazeile, Seitenleiste und Weiterlesen-Block sind abgezogen
 | `/digitale-funkuebung/` | 826 | 800 | 51 | 152 | 7 KB |
 | `/funkuebung-katastrophenschutz/` | 827 | 800 | 50 | 149 | 7 KB |
 | `/meldevordruck/` | 831 | 800 | 51 | 150 | 7 KB |
-| `/funksprueche/` | 831 | 800 | 51 | 156 | 7 KB |
+| `/funksprueche/` | 831 | 800 | 51 | 156 | 8 KB |
 | `/funkrufnamen-thw/` | 832 | 800 | 51 | 149 | 8 KB |
 | `/funkrufnamen/` | 846 | 800 | 55 | 155 | 8 KB |
 | `/wissen/` | 847 | 800 | 53 | 155 | 9 KB |
@@ -31,13 +31,14 @@ Inhaltsverzeichnis, Metazeile, Seitenleiste und Weiterlesen-Block sind abgezogen
 | `/funkuebung-thw/` | 1012 | 1000 | 52 | 156 | 8 KB |
 | `/bos-funk/` | 1058 | 800 | 51 | 153 | 9 KB |
 | `/funkreichweite/` | 1097 | 800 | 51 | 156 | 9 KB |
-| `/regiebuch-funkuebung/` | 1125 | 1100 | 52 | 157 | 8 KB |
 | `/funkuebung-feuerwehr/` | 1136 | 1100 | 51 | 156 | 8 KB |
 | `/uebungsfunkverkehr/` | 1155 | 800 | 52 | 155 | 9 KB |
+| `/regiebuch-funkuebung/` | 1159 | 1100 | 52 | 157 | 8 KB |
+| `/x-zeit/` | 1170 | 800 | 53 | 153 | 8 KB |
 | `/sprechfunk-regeln/` | 1173 | 800 | 54 | 147 | 9 KB |
 | `/buchstabiertafel/` | 1198 | 800 | 53 | 157 | 10 KB |
 | `/funkuebung-szenarien/` | 1220 | 1200 | 51 | 149 | 9 KB |
-| `/anleitung/` | 1261 | 800 | 51 | 154 | 10 KB |
+| `/anleitung/` | 1262 | 800 | 51 | 154 | 10 KB |
 
 ## Verstöße: 0
 

--- a/seo/internal-links-report.md
+++ b/seo/internal-links-report.md
@@ -11,9 +11,9 @@ auf jeder Seite gleich sind.
 
 ## Überblick
 
-- Seiten in der Registry: 30
-- davon Inhaltsseiten: 27
-- Fließtext-Links gesamt: 303
+- Seiten in der Registry: 31
+- davon Inhaltsseiten: 28
+- Fließtext-Links gesamt: 315
 - Verstöße: 0
 - Seiten ohne eingehenden Fließtext-Link: 0
 
@@ -25,27 +25,28 @@ Keine. Jede Inhaltsseite hat mindestens einen eingehenden Fließtext-Link.
 
 | Seite | eingehend | ausgehend |
 | --- | ---: | ---: |
-| `/meldevordruck/` | 26 | 4 |
+| `/meldevordruck/` | 27 | 5 |
+| `/regiebuch-funkuebung/` | 25 | 8 |
 | `/buchstabiertafel/` | 23 | 6 |
 | `/funksprueche/` | 23 | 4 |
-| `/regiebuch-funkuebung/` | 23 | 7 |
 | `/sprechfunk-regeln/` | 18 | 19 |
-| `/anleitung/` | 15 | 12 |
-| `/funkuebung-planen/` | 13 | 17 |
+| `/anleitung/` | 16 | 13 |
+| `/funkuebung-planen/` | 14 | 17 |
 | `/bos-funk/` | 13 | 13 |
 | `/open-source/` | 13 | 6 |
 | `/funkuebung-dienstabend/` | 12 | 11 |
-| `/digitale-funkuebung/` | 10 | 7 |
+| `/digitale-funkuebung/` | 11 | 7 |
 | `/funkuebung-thw/` | 8 | 10 |
+| `/betriebsworte/` | 8 | 12 |
 | `/funkrufnamen/` | 8 | 13 |
 | `/funkuebung-feuerwehr/` | 7 | 8 |
 | `/funkuebung-vorlage/` | 7 | 12 |
-| `/betriebsworte/` | 7 | 12 |
-| `/funkuebung-szenarien/` | 6 | 14 |
+| `/funkuebung-szenarien/` | 6 | 15 |
 | `/uebungsfunkverkehr/` | 6 | 12 |
 | `/funkreichweite/` | 6 | 14 |
 | `/verkehrsarten/` | 4 | 12 |
 | `/antennen/` | 4 | 7 |
+| `/x-zeit/` | 4 | 8 |
 | `/faq/` | 4 | 11 |
 | `/funktionen/` | 3 | 21 |
 | `/funkuebung-katastrophenschutz/` | 3 | 8 |
@@ -58,26 +59,27 @@ Keine. Jede Inhaltsseite hat mindestens einen eingehenden Fließtext-Link.
 | Ziel | Varianten | Ankertexte |
 | --- | ---: | --- |
 | `/meldevordruck/` | 8 | „druckvordrucke“, „lagemeldung“, „meldevordruck“, „meldevordruck und nachrichtenvordruck“, „meldevordrucke“, „nachrichtenvordruck“, „pdf-vordrucken“, „vordrucke“ |
+| `/regiebuch-funkuebung/` | 11 | „auswertung“, „live-cockpit“, „live-nachrichtenplan“, „live-übungsleitung“, „live-übungsleitung ansehen“, „nachrichtenplan“, „nachrichtenplan ansehen“, „regiebuch“, „regiebuch der übung“, „regiebuch mit live-übungsleitung“, „übungsleitung“ |
 | `/buchstabiertafel/` | 4 | „buchstabieren“, „buchstabiertafel“, „buchstabiertafel inland“, „zahlentafel“ |
 | `/funksprueche/` | 11 | „beispiel-funksprüche ansehen“, „fertige funksprüche“, „funkspruch-vorlagen“, „funksprüche“, „funksprüche ansehen“, „funksprüche für übungen“, „funksprüchen“, „vorlagen“, „über 1.800 funksprüche“, „über 1.800 funksprüchen“, „übungspool“ |
-| `/regiebuch-funkuebung/` | 10 | „auswertung“, „live-cockpit“, „live-nachrichtenplan“, „live-übungsleitung“, „live-übungsleitung ansehen“, „nachrichtenplan“, „regiebuch“, „regiebuch der übung“, „regiebuch mit live-übungsleitung“, „übungsleitung“ |
 | `/sprechfunk-regeln/` | 6 | „anrufverfahren“, „funkdisziplin“, „sprechfunk-regeln“, „sprechfunk-regeln im bos-funk“, „sprechfunkregeln“, „sprechfunkverkehr“ |
 | `/anleitung/` | 4 | „anleitung“, „schritt-für-schritt-anleitung“, „sprechfunkübung“, „zur anleitung“ |
-| `/funkuebung-planen/` | 7 | „funkübung“, „funkübung planen“, „geplanten funkübung“, „planen“, „schritt-für-schritt-planung“, „übung“, „übungsplanung“ |
+| `/funkuebung-planen/` | 8 | „funkübung“, „funkübung planen“, „geplanten funkübung“, „planen“, „planung einer funkübung“, „schritt-für-schritt-planung“, „übung“, „übungsplanung“ |
 | `/bos-funk/` | 5 | „bos-funk grundlagen“, „bos-funk-grundlagen zu digitalfunk und tetra“, „digitalfunk“, „digitalfunk bos“, „rufgruppen im thw“ |
 | `/open-source/` | 2 | „kostenlos, ohne anmeldung, quelloffen“, „kostenlos, quelloffen (eupl-1.2) und datensparsam“ |
 | `/funkuebung-dienstabend/` | 4 | „ablauf für den dienstabend“, „dienstabend“, „funkübung am dienstabend“, „funkübung für den dienstabend“ |
-| `/digitale-funkuebung/` | 4 | „digital am smartphone“, „digitale funkübung“, „digitale funkübung per smartphone“, „teilnehmeransicht“ |
+| `/digitale-funkuebung/` | 5 | „digital am smartphone“, „digitale funkübung“, „digitale funkübung per smartphone“, „digitalen funkübung“, „teilnehmeransicht“ |
 | `/funkuebung-thw/` | 4 | „funkübung im thw“, „funkübung thw“, „thw“, „thw-ortsverbände“ |
+| `/betriebsworte/` | 4 | „betriebsworte“, „betriebsworte im bos-funk“, „kommen“, „„ich buchstabiere““ |
 | `/funkrufnamen/` | 4 | „funkrufnamen“, „funkrufnamen im bos-funk“, „funkrufnamen verstehen“, „funkrufnamens“ |
 | `/funkuebung-feuerwehr/` | 2 | „feuerwehr“, „funkübung feuerwehr“ |
 | `/funkuebung-vorlage/` | 4 | „fertige vorlagen“, „fertige vorlagen ansehen“, „funkübungen als pdf“, „übungs-vorlagen“ |
-| `/betriebsworte/` | 4 | „betriebsworte“, „betriebsworte im bos-funk“, „kommen“, „„ich buchstabiere““ |
 | `/funkuebung-szenarien/` | 5 | „12 szenarien für die funkübung“, „eingekleideten szenario-übung“, „szenario“, „szenario-ideen“, „übungsszenario“ |
 | `/uebungsfunkverkehr/` | 2 | „blitz- und staatsnot-nachrichten“, „übungsfunkverkehr“ |
 | `/funkreichweite/` | 3 | „merkregeln zur störungsbeseitigung“, „reichweite“, „reichweite von funkwellen“ |
 | `/verkehrsarten/` | 2 | „verkehrsarten“, „verkehrsarten und relaisbetrieb“ |
 | `/antennen/` | 3 | „antennen“, „antennen und antennenleitungen“, „art der antenne“ |
+| `/x-zeit/` | 4 | „der x-zeit-modus“, „fälligkeitszeitpunkt als x+n“, „x-zeit“, „zeitversetzte fälligkeiten“ |
 | `/faq/` | 2 | „faq“, „häufige fragen“ |
 | `/funktionen/` | 3 | „alle funktionen im überblick“, „bausteinen der anwendung“, „überblick über die funktionen“ |
 | `/funkuebung-katastrophenschutz/` | 3 | „funkübung im katastrophenschutz“, „hilfsorganisationen“, „katastrophenschutz“ |

--- a/src/pages/anleitung.html
+++ b/src/pages/anleitung.html
@@ -150,7 +150,7 @@
                          alt="Kopfdaten-Karte mit Feldern für Datum, Name der Übung, Rufgruppe und Funkrufname der Übungsleitung"
                          width="912" height="1052" loading="lazy" decoding="async">
                     <figcaption class="figure-caption">Die Kopfdaten der Übung. Der Spiel-Modus
-                        „X-Zeit“ verteilt Nachrichten zusätzlich auf feste Zeitfenster.</figcaption>
+                        <a href="../x-zeit/">der X-Zeit-Modus</a> verteilt Nachrichten zusätzlich auf feste Zeitfenster.</figcaption>
                 </figure>
 
                 <h3 class="h5" id="teilnehmer">Schritt 2: Teilnehmer eintragen</h3>

--- a/src/pages/funkuebung-szenarien.html
+++ b/src/pages/funkuebung-szenarien.html
@@ -254,7 +254,7 @@
             <div class="card-body">
                 <p>Ein Szenario besteht aus drei Angaben: Lage, Auftrag und Zeitrahmen. Die Lage sagt, was passiert ist. Der Auftrag sagt, was die Funkstellen tun sollen. Der Zeitrahmen begrenzt die Übung, damit sie nicht ausläuft.</p>
                 <p>Mehr braucht es nicht, und mehr schadet sogar. Eine ausgefeilte Hintergrundgeschichte kostet Einweisungszeit und verwirrt Einsteiger. Zwei Sätze zur Lage genügen, wenn die Funksprüche dazu passen.</p>
-                <p>Der Zeitrahmen wird über die X-Zeit gesetzt. Wer die Lage um X+10 eskalieren lässt, etwa mit einer zusätzlichen Einsatzstelle, erzeugt eine Belastungsspitze an einer geplanten Stelle.</p>
+                <p>Der Zeitrahmen wird über <a href="../x-zeit/">zeitversetzte Fälligkeiten</a> gesetzt. Wer die Lage um X+10 eskalieren lässt, etwa mit einer zusätzlichen Einsatzstelle, erzeugt eine Belastungsspitze an einer geplanten Stelle.</p>
             </div>
         </section>
 

--- a/src/pages/meldevordruck.html
+++ b/src/pages/meldevordruck.html
@@ -134,7 +134,7 @@
             <div class="card-body">
                 <p>Der Meldevordruck hält die Angaben fest, die eine Nachricht nachvollziehbar machen:</p>
                 <ul>
-                    <li><strong>Nummer</strong> – laufende Nummer der Nachricht, in Übungen wahlweise der Zeitpunkt als X-Zeit.</li>
+                    <li><strong>Nummer</strong> – laufende Nummer der Nachricht, in Übungen wahlweise der <a href="../x-zeit/">Fälligkeitszeitpunkt als X+n</a>.</li>
                     <li><strong>Absender</strong> – Funkrufname der Stelle, die die Nachricht absetzt.</li>
                     <li><strong>Empfänger</strong> – ein einzelner Funkrufname, mehrere Empfänger oder alle Teilnehmer.</li>
                     <li><strong>Nachrichtentext</strong> – der eigentliche Wortlaut des Funkspruchs.</li>

--- a/src/pages/regiebuch-funkuebung.html
+++ b/src/pages/regiebuch-funkuebung.html
@@ -181,8 +181,9 @@
         <section class="card shadow-sm mb-4">
             <div class="card-header"><h2 class="h4 mb-0" id="x-zeit">X-Zeit: der Zeitplan hinter dem Plan</h2></div>
             <div class="card-body">
-                <p>Der Nachrichtenplan sagt, was gefunkt wird, aber nicht wann. Dafür gibt es die X-Zeit. Sie ist eine relative Zeitangabe ab Übungsbeginn: X+15 bedeutet fünfzehn Minuten nach dem Start. Der Vorteil gegenüber einer festen Uhrzeit liegt darin, dass sich eine Verzögerung am Anfang nicht durch den ganzen Plan schleppt.</p>
+                <p>Der Nachrichtenplan sagt, was gefunkt wird, aber nicht wann. Dafür gibt es die <a href="../x-zeit/">X-Zeit</a>. Sie ist eine relative Zeitangabe ab Übungsbeginn: X+15 bedeutet fünfzehn Minuten nach dem Start. Der Vorteil gegenüber einer festen Uhrzeit liegt darin, dass sich eine Verzögerung am Anfang nicht durch den ganzen Plan schleppt.</p>
                 <p>In der Übungsleitung wird die X-Zeit-Basis auf den tatsächlichen Übungsbeginn gesetzt. Danach rechnet die Ansicht mit. Sie zeigt die laufende Uhrzeit, die Laufzeit seit Beginn und den Vergleich zwischen Soll und Ist. Wer vierzig Minuten nach dem Start bei Spruch 30 von 80 steht, weiß, dass die Übung länger dauert als geplant.</p>
+                <p>Wie die Slots zustande kommen, entscheidet sich vorher im Generator: Intervall und Start-Offset legen die Zeitachse fest, bevor der Plan gedruckt wird. Die Formel dahinter steht mit einem durchgerechneten Beispiel auf der eigenen Seite.</p>
                 <p>Praktisch nutzt man das, um gegenzusteuern, bevor die Zeit knapp wird. Zwei Funkstellen mit weniger Sprüchen entlasten den Kanal sofort.</p>
             </div>
         </section>

--- a/src/pages/x-zeit.html
+++ b/src/pages/x-zeit.html
@@ -1,0 +1,361 @@
+<!DOCTYPE html>
+<html lang="de">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>X-Zeit in der Funkübung: zeitversetzt planen und üben</title>
+    <link rel="icon" type="image/png" href="../assets/favicon.png">
+    <link rel="canonical" href="https://sprechfunk-uebung.de/x-zeit/">
+    <meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1">
+    <meta name="theme-color" content="#0d6efd">
+
+    <meta name="description" content="X-Zeit heißt: Nachrichten werden relativ zum Übungsbeginn fällig. Wie der X-Zeit-Modus mit Intervall und Start-Offset rechnet, an einem Beispiel erklärt.">
+    <meta name="author" content="Johannes Rudolph">
+
+    <meta property="og:title" content="X-Zeit in der Funkübung: zeitversetzt planen und üben">
+    <meta property="og:description" content="X-Zeit heißt: Nachrichten werden relativ zum Übungsbeginn fällig. Wie der X-Zeit-Modus mit Intervall und Start-Offset rechnet, an einem Beispiel erklärt.">
+    <meta property="og:url" content="https://sprechfunk-uebung.de/x-zeit/">
+    <meta property="og:type" content="article">
+    <meta property="og:locale" content="de_DE">
+    <meta property="og:site_name" content="Sprechfunk Übungsgenerator">
+    <meta property="og:image" content="https://sprechfunk-uebung.de/assets/og-image.png">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">
+    <meta property="og:image:alt" content="Sprechfunk Übungsgenerator – Übungen für den BOS-Sprechfunk erstellen">
+
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="X-Zeit in der Funkübung: zeitversetzt planen und üben">
+    <meta name="twitter:description" content="X-Zeit heißt: Nachrichten werden relativ zum Übungsbeginn fällig. Wie der X-Zeit-Modus mit Intervall und Start-Offset rechnet, an einem Beispiel erklärt.">
+    <meta name="twitter:image" content="https://sprechfunk-uebung.de/assets/og-image.png">
+
+    <link rel="stylesheet" href="../bundle.css">
+    <link rel="stylesheet" href="../style.css">
+
+    <!-- GoatCounter: cookielose, anonyme Reichweitenmessung -->
+    <script data-goatcounter="https://sprechfunk-uebung.goatcounter.com/count"
+            async src="//gc.zgo.at/count.js"></script>
+
+    <script>
+        // Gleiche Theme-Auswahl wie in der App anwenden (statische Seiten laden kein Bundle).
+        document.addEventListener("DOMContentLoaded", function () {
+            var stored = localStorage.getItem("theme");
+            if (stored) {
+                document.body.setAttribute("data-theme", stored);
+            }
+        });
+    </script>
+</head>
+
+<body data-theme="light">
+<header class="app-header">
+    <div class="container app-header-grid">
+        <div class="app-header-title">
+            <p class="h2 mb-0">
+                <i class="fas fa-broadcast-tower"></i> Sprechfunk Übungsgenerator
+            </p>
+        </div>
+        <div class="app-header-actions d-none d-md-flex">
+            <a href="../" class="btn btn-primary">
+                <i class="fas fa-arrow-left"></i> Zur Anwendung
+            </a>
+            <a href="../anleitung/" class="btn btn-info">
+                <i class="fas fa-book"></i> Anleitung
+            </a>
+            <a href="https://github.com/wattnpapa/sprechfunk-uebung" class="btn btn-dark">
+                <i class="fab fa-github"></i> GitHub
+            </a>
+        </div>
+    </div>
+</header>
+
+<main class="container my-4 app-view-shell">
+    <nav aria-label="Brotkrumennavigation" class="mb-3">
+        <ol class="breadcrumb mb-0">
+            <li class="breadcrumb-item"><a href="../">Startseite</a></li>
+            <li class="breadcrumb-item active" aria-current="page">X-Zeit</li>
+        </ol>
+    </nav>
+
+    <article>
+        <div class="card mb-3">
+            <div class="card-body">
+                <h1 class="h3">X-Zeit in der Sprechfunkübung</h1>
+                <p>
+                    <strong>X-Zeit</strong> ist eine relative Zeitangabe. <strong>X+15</strong>
+                    bedeutet: fünfzehn Minuten nach dem festgelegten Beginn. Im Übungsbetrieb
+                    tritt sie an die Stelle fester Uhrzeiten im Ablaufplan.
+                </p>
+                <p class="mb-0">
+                    Der <strong>Sprechfunk Übungsgenerator</strong> hat dafür einen eigenen
+                    Spiel-Modus. Er legt jede Nachricht der Übung auf einen X-Zeit-Slot und
+                    rechnet während des Betriebs mit. Diese Seite erklärt die Rechnung dahinter
+                    und zeigt, wie sich Intervall und Start-Offset sinnvoll wählen lassen.
+                </p>
+            </div>
+        </div>
+
+        <section class="card shadow-sm mb-4">
+            <div class="card-header"><h2 class="h4 mb-0" id="begriff">Was die X-Zeit bezeichnet</h2></div>
+            <div class="card-body">
+                <p>
+                    Die X-Zeit ist ein Bezugszeitpunkt. Er heißt X, weil er beim Planen noch
+                    nicht feststeht. Alle weiteren Angaben zählen von ihm aus: X+5, X+20,
+                    X+90.
+                </p>
+                <p>
+                    Der Zeitpunkt selbst wird erst am Übungstag gesetzt. Bis dahin bleibt der
+                    Plan gültig, egal ob die Übung um 19:00 oder um 19:25 beginnt. Genau das ist
+                    der Zweck der Schreibweise.
+                </p>
+                <p class="mb-0">
+                    Zu unterscheiden ist die X-Zeit von der Uhrzeit im
+                    <a href="../meldevordruck/">Meldevordruck</a>. Dort steht, wann eine
+                    Nachricht tatsächlich aufgenommen wurde. Die X-Zeit sagt, wann sie fällig
+                    war.
+                </p>
+            </div>
+        </section>
+
+        <section class="card shadow-sm mb-4">
+            <div class="card-header"><h2 class="h4 mb-0" id="warum">Warum relative Zeiten robuster sind</h2></div>
+            <div class="card-body">
+                <p>
+                    Ein Ablaufplan mit Uhrzeiten ist nach zehn Minuten Verzug falsch. Wer ihn
+                    dann noch benutzt, korrigiert im Kopf mit. Nach der dritten Korrektur
+                    stimmen die Zahlen für niemanden mehr.
+                </p>
+                <p>
+                    Bei relativen Angaben bleibt der Abstand zwischen zwei Ereignissen
+                    erhalten. Verschiebt sich der Beginn, verschiebt sich der ganze Plan
+                    mit. Es gibt nur einen Wert zu korrigieren, und zwar den Startzeitpunkt.
+                </p>
+                <p class="mb-0">
+                    Dazu kommt die Wiederverwendbarkeit. Derselbe Plan trägt zwei Gruppen an
+                    zwei Abenden, ohne dass eine Zeile geändert wird. Für die
+                    <a href="../funkuebung-planen/">Planung einer Funkübung</a> heißt das:
+                    einmal rechnen, mehrfach nutzen.
+                </p>
+            </div>
+        </section>
+
+        <section class="card shadow-sm mb-4">
+            <div class="card-header"><h2 class="h4 mb-0" id="modus">Der X-Zeit-Modus im Generator</h2></div>
+            <div class="card-body">
+                <p>
+                    In den Kopfdaten der Übung steht die Auswahl <strong>Spiel-Modus</strong>
+                    mit zwei Möglichkeiten. <em>Klassisch</em> vergibt keine Zeiten; jede
+                    Funkstelle arbeitet ihre Liste in eigenem Tempo ab. <em>X-Zeit</em>
+                    schaltet zwei zusätzliche Felder frei.
+                </p>
+                <ul>
+                    <li>
+                        <strong>Intervall (Min.)</strong> – der Abstand zwischen zwei
+                        aufeinanderfolgenden Nachrichten der Übung. Vorbelegt mit 3 Minuten.
+                    </li>
+                    <li>
+                        <strong>Start-Offset (Min.)</strong> – die Vorlaufzeit, bevor die erste
+                        Nachricht fällig wird. Vorbelegt mit 0 Minuten.
+                    </li>
+                </ul>
+                <p class="mb-0">
+                    Aus diesen zwei Zahlen entsteht die gesamte Zeitachse. Sie steht danach im
+                    <a href="../regiebuch-funkuebung/">Nachrichtenplan</a> und auf den
+                    Druckunterlagen.
+                </p>
+            </div>
+        </section>
+
+        <section class="card shadow-sm mb-4">
+            <div class="card-header"><h2 class="h4 mb-0" id="beispiel">Ein durchgerechnetes Beispiel</h2></div>
+            <div class="card-body">
+                <p>
+                    Die Zuteilung folgt einer einfachen Formel. Für die Nachricht an Position
+                    <em>n</em> gilt:
+                </p>
+                <p><strong>X+ = Start-Offset + n × Intervall</strong></p>
+                <p>
+                    <em>n</em> zählt über die ganze Übung, nicht je Funkstelle. Angenommen, acht
+                    Funkstellen setzen je sechs Funksprüche ab, der Anmeldungs-Funkspruch ist
+                    aktiv, das Intervall beträgt 2 Minuten und der Start-Offset 5 Minuten.
+                </p>
+                <ul>
+                    <li>
+                        Die acht Anmeldungen liegen alle auf <strong>X+0</strong>. Sie sind der
+                        Beginn und nehmen keinen eigenen Slot in der Reihe ein.
+                    </li>
+                    <li>
+                        Es bleiben 8 × 5 = <strong>40 Nachrichten</strong> für die Zeitachse.
+                    </li>
+                    <li>
+                        Die erste liegt auf 5 + 1 × 2 = <strong>X+7</strong>, die letzte auf
+                        5 + 40 × 2 = <strong>X+85</strong>.
+                    </li>
+                </ul>
+                <p class="mb-0">
+                    Der Übungsbetrieb dauert damit 85 Minuten nach dem Start. Die Reihenfolge
+                    läuft rundenweise: erst der zweite Funkspruch aller acht Stellen, dann der
+                    dritte, und so weiter. Damit ist jede Funkstelle über den ganzen Abend
+                    verteilt beschäftigt.
+                </p>
+            </div>
+        </section>
+
+        <section class="card shadow-sm mb-4">
+            <div class="card-header"><h2 class="h4 mb-0" id="intervall">Das Intervall gegen die Gesamtzahl rechnen</h2></div>
+            <div class="card-body">
+                <p>
+                    Hier steckt die häufigste Fehlannahme. Das Intervall gilt für die Übung als
+                    Ganzes, nicht für die einzelne Funkstelle. Drei Minuten klingen nach wenig
+                    und ergeben bei vielen Teilnehmern eine lange Übung.
+                </p>
+                <p>
+                    Zehn Funkstellen mit je zehn Funksprüchen kommen auf 90 Nachrichten in der
+                    Reihe. Bei einem Intervall von 3 Minuten liegt die letzte auf X+270. Das
+                    sind viereinhalb Stunden.
+                </p>
+                <p>
+                    Deshalb lohnt die Rechnung in die andere Richtung. Für einen Rahmen von
+                    90 Minuten und 40 Nachrichten bleiben gut 2 Minuten je Nachricht. Als
+                    Faustformel:
+                </p>
+                <p>
+                    <strong>Dauer ≈ Start-Offset + Funkstellen × (Funksprüche − 1) × Intervall</strong>
+                </p>
+                <p class="mb-0">
+                    Nach unten gibt es eine Grenze. Ein vollständiger Verkehr mit Anruf,
+                    Nachricht und Bestätigung braucht auf dem Kanal 45 bis 90 Sekunden. Ein
+                    Intervall unter einer Minute erzeugt daher Wartezeiten, weil die
+                    Fälligkeiten schneller auflaufen als der Kanal sie abarbeitet.
+                </p>
+            </div>
+        </section>
+
+        <section class="card shadow-sm mb-4">
+            <div class="card-header"><h2 class="h4 mb-0" id="teilnehmer">Was die Funkstelle am Gerät sieht</h2></div>
+            <div class="card-body">
+                <p>
+                    In der Teilnehmeransicht erscheint im X-Zeit-Modus ein Banner mit einem
+                    Zeitfeld und der Schaltfläche <em>Jetzt starten</em>. Damit setzt die
+                    Funkstelle ihre X-Zeit-Basis auf den tatsächlichen Beginn. Ohne gesetzte
+                    Basis gibt es keinen Countdown, sondern einen Hinweis darauf.
+                </p>
+                <p>
+                    Ist die Basis gesetzt, zeigt die Ansicht die Restzeit bis zur nächsten
+                    fälligen Nachricht. Jede Zeile der Tabelle trägt ihren Slot als Kennzeichen
+                    X+n.
+                </p>
+                <p class="mb-0">
+                    Dazu kommt der Fokus-Modus, der nur in diesem Spiel-Modus verfügbar ist. Er
+                    blendet die Tabelle aus und zeigt allein die aktuell fällige Nachricht.
+                    Künftige Texte bleiben bis zu ihrer Fälligkeit verborgen. Wer vorausliest,
+                    kann sich also keinen Vorsprung verschaffen – ein Vorteil gegenüber der
+                    ausgedruckten Liste bei der
+                    <a href="../digitale-funkuebung/">digitalen Funkübung</a>.
+                </p>
+            </div>
+        </section>
+
+        <section class="card shadow-sm mb-4">
+            <div class="card-header"><h2 class="h4 mb-0" id="leitung">Was die Übungsleitung sieht</h2></div>
+            <div class="card-body">
+                <p>
+                    Die Übungsleitung bekommt im X-Zeit-Modus ein Cockpit. Es zeigt die laufende
+                    Uhrzeit, die Laufzeit seit der Basis und den Vergleich zwischen Soll und
+                    Ist. Im klassischen Modus bleibt es ausgeblendet, weil dort keine Zeitachse
+                    existiert.
+                </p>
+                <p>
+                    Das Soll ist die Anzahl der Nachrichten, die laut Plan bereits fällig
+                    sind. Das Ist zählt die tatsächlich abgesetzten. Aus der Differenz entsteht
+                    der Plan-Status.
+                </p>
+                <ul>
+                    <li>Ist mindestens gleich Soll: <strong>im Plan</strong>.</li>
+                    <li>Ein oder zwei Nachrichten Rückstand: Warnstufe.</li>
+                    <li>Ab drei Nachrichten Rückstand: deutliche Kennzeichnung.</li>
+                </ul>
+                <p class="mb-0">
+                    Der Nutzen liegt im Gegensteuern, bevor die Zeit knapp wird. Zwei
+                    Funkstellen mit weniger Sprüchen entlasten den Kanal sofort.
+                </p>
+            </div>
+        </section>
+
+        <section class="card shadow-sm mb-4">
+            <div class="card-header"><h2 class="h4 mb-0" id="vordrucke">X+n auf den Vordrucken</h2></div>
+            <div class="card-body">
+                <p>
+                    Die X-Zeit steht auch auf Papier. In Meldevordruck und Nachrichtenvordruck
+                    tritt sie an die Stelle der laufenden Nummer und erscheint dort als X+n.
+                </p>
+                <p class="mb-0">
+                    Damit funktioniert eine X-Zeit-Übung ohne jeden Bildschirm. Die
+                    Übungsleitung nennt beim Start die Uhrzeit, alle notieren sie, und jede
+                    Funkstelle rechnet ihre Fälligkeiten selbst aus. Der Rechenschritt ist
+                    ausdrücklich Teil der Übung.
+                </p>
+            </div>
+        </section>
+
+        <section class="card shadow-sm mb-4">
+            <div class="card-header"><h2 class="h4 mb-0" id="grenzen">Grenzen des Verfahrens</h2></div>
+            <div class="card-body">
+                <p>
+                    Eine getaktete Übung verzeiht weniger. Wer zurückfällt, bekommt die nächste
+                    Fälligkeit trotzdem, und der Rückstand wächst. Für eine erste Übung nach
+                    dem Lehrgang ist der klassische Modus deshalb die bessere Wahl.
+                </p>
+                <p>
+                    Ein Slot ist außerdem keine Sendeerlaubnis. Fällig heißt: ab jetzt darf die
+                    Nachricht abgesetzt werden, sobald der Kanal frei ist. Die
+                    <a href="../betriebsworte/">Betriebsworte</a> und die Regeln zur
+                    Verkehrsabwicklung gelten unverändert.
+                </p>
+                <p class="mb-0">
+                    Nachrichten an alle Funkstellen belegen einen eigenen Slot. Sie brauchen auf
+                    dem Kanal länger als eine gerichtete Nachricht, weil jede Gegenstelle
+                    einzeln bestätigt. Wer viele Rundsprüche einplant, rechnet das Intervall
+                    besser großzügiger.
+                </p>
+            </div>
+        </section>
+
+        <div class="card">
+            <div class="card-body">
+                <h2 class="h4">Übung mit X-Zeit erstellen</h2>
+                <p>
+                    Teilnehmer eintragen, Spiel-Modus X-Zeit wählen, Intervall und Start-Offset
+                    setzen – die Zeitachse rechnet der Generator.
+                </p>
+                <p class="mb-0">
+                    <a href="../" class="btn btn-primary">Übung erstellen</a>
+                    <a href="../regiebuch-funkuebung/" class="btn btn-outline-primary">Nachrichtenplan ansehen</a>
+                    <a href="../anleitung/" class="btn btn-outline-primary">Zur Anleitung</a>
+                </p>
+            </div>
+        </div>
+    </article>
+</main>
+
+<footer class="main-footer">
+    <span class="footer-links">
+        <a href="../">Anwendung</a>
+        <a href="../anleitung/">Anleitung</a>
+        <a href="../buchstabiertafel/">Buchstabiertafel</a>
+        <a href="../meldevordruck/">Meldevordruck</a>
+        <a href="../funksprueche/">Funksprüche</a>
+        <a href="../faq/">FAQ</a>
+    </span>
+    <span class="footer-links">
+        <a href="../impressum/">Impressum</a>
+        <a href="../datenschutz/">Datenschutz</a>
+        <a href="mailto:johannes.rudolph@thw-oldenburg.de">Kontakt</a>
+        <a href="https://github.com/wattnpapa/sprechfunk-uebung" target="_blank" rel="noopener noreferrer">GitHub</a>
+        <a href="https://github.com/wattnpapa/sprechfunk-uebung/blob/main/LICENSE" target="_blank" rel="noopener noreferrer">EUPL-1.2-Lizenz</a>
+    </span>
+</footer>
+
+</body>
+
+</html>

--- a/tests/seo/SchemaGraph.test.ts
+++ b/tests/seo/SchemaGraph.test.ts
@@ -87,7 +87,7 @@ function alleSchluessel(wert: unknown, treffer: string[] = []): string[] {
 
 describe("Schema-Graph je Seite", () => {
     it("die Registry deckt alle 30 ausgelieferten URLs ab", () => {
-        expect(SITE_PAGES).toHaveLength(30);
+        expect(SITE_PAGES).toHaveLength(31);
     });
 
     for (const page of SITE_PAGES) {


### PR DESCRIPTION
## Was

Neue Seite `/x-zeit/` – die erste aus Priorität 1 von AP-07.

Der Generator hat den Spiel-Modus **X-Zeit** mit Intervall und Start-Offset, also die
tiefere Umsetzung als der Wettbewerb. Eine eigene URL dazu gab es nicht. Das Thema
existierte nur als dreiabsätziger Abschnitt in `/regiebuch-funkuebung/`, der die
Rechnung dahinter nicht erklärt.

## Warum keine Überschneidung mit einer Bestandsseite

Geprüft gegen `/regiebuch-funkuebung/`, `/funkuebung-planen/` und `/anleitung/`.

| Seite | Suchintention | Verhältnis zur neuen Seite |
| --- | --- | --- |
| `/regiebuch-funkuebung/` | „Was steht im Nachrichtenplan und was zeigt die Übungsleitung?" | behält den Soll-Ist-Vergleich im Cockpit, verweist für die Berechnung auf `/x-zeit/` |
| `/funkuebung-planen/` | „Wie plane ich eine Funkübung von Anfang bis Ende?" | sieben Schritte, keine Zeitachse |
| `/anleitung/` | „Wie bediene ich den Generator?" | nennt den Modus in einer Bildunterschrift, erklärt ihn nicht |

Die Überschneidung liegt bei etwa 150 von 1170 Wörtern und betrifft ausschließlich die
Definition „X+15 heißt fünfzehn Minuten nach dem Start". Sie muss auf beiden Seiten
stehen, damit keine der beiden ohne Vorwissen unlesbar ist.

Der Regiebuch-Abschnitt wurde nicht ausgelagert, sondern gekürzt und verlinkt. Grund:
`/regiebuch-funkuebung/` hat ein Wortziel von 1100 und liegt bei 1125 – ein Auslagern
von 160 Wörtern hätte die Seite unter ihr Ziel gedrückt und Ersatztext ohne Substanz
erzwungen.

## Inhalt

Die Seite dokumentiert die tatsächliche Implementierung, nicht eine allgemeine
Beschreibung:

- **Formel** `X+ = Start-Offset + n × Intervall` aus `GenerationService.assignXZeitSlots`.
  `n` zählt global über die Übung, nicht je Funkstelle. Anmeldungs-Funksprüche liegen
  auf `X+0`.
- **Durchgerechnetes Beispiel:** 8 Funkstellen, je 6 Funksprüche, Intervall 2, Offset 5
  → 40 Nachrichten auf der Achse, erste `X+7`, letzte `X+85`.
- **Häufige Fehlannahme:** das Intervall gilt für die Übung, nicht je Funkstelle.
  10 × 10 Funksprüche bei Intervall 3 ergeben `X+270`, also viereinhalb Stunden.
- **Fokus-Modus** der Teilnehmeransicht, der künftige Nachrichtentexte bis zur
  Fälligkeit verbirgt (`TeilnehmerView.buildFokusZustand`).
- **Plan-Status** der Übungsleitung nach `berechnePlanStatus`: Warnstufe bis zwei
  Nachrichten Rückstand, ab drei deutliche Kennzeichnung.
- **X+n auf den Vordrucken** (`pdf/Meldevordruck.ts`, `pdf/Nachrichtenvordruck.ts`).

## Fachlich zu prüfen

Vier Aussagen, bei denen ich mich auf Plausibilität statt auf eine belegbare Quelle
stütze. Ich habe bewusst keine Dienstvorschrift zitiert, weil ich für keine dieser
Aussagen eine Fundstelle nennen kann.

1. **Begriff „X-Zeit".** Ich beschreibe ihn als Planungskonvention für einen
   Bezugszeitpunkt. Ob im BOS-Bereich „X-Zeit", „Zeitpunkt X" oder eine andere
   Schreibweise üblich ist – und ob eine Vorschrift das regelt – konnte ich nicht
   belegen. Falls es eine Fundstelle gibt, sollte sie ergänzt werden.
2. **„45 bis 90 Sekunden je Verkehr"** als Untergrenze für das Intervall. Der Wert
   stammt aus dem Dauermodell des Generators (Statistik-Ansicht), nicht aus einer
   Messung im Übungsbetrieb und nicht aus einer Vorschrift.
3. **Rundsprüche belegen den Kanal länger, „weil jede Gegenstelle einzeln bestätigt".**
   Ob im Übungsbetrieb tatsächlich jede Stelle einzeln bestätigt oder ob eine
   Sammelbestätigung üblich ist, hängt vermutlich von der Verkehrsform ab. Bitte prüfen.
4. **Didaktische Empfehlung**, für die erste Übung nach dem Lehrgang den klassischen
   Modus zu wählen. Das ist meine Einschätzung, kein Ausbildungsstandard.

## Abnahmekriterien

- [x] ≥ 900 Wörter → **1170** (Bericht: `seo/content-quality-report.md`)
- [x] Seitenformat aus AP-06 vollständig: Metazeile, „Kurz gesagt", Inhaltsverzeichnis, `h2`-ids, FAQ, Weiterlesen, CTA
- [x] In Registry, Sitemap, Hub (`uebungen`) und Weiterlesen-Graph eingetragen
- [x] Mindestens drei eingehende Fließtext-Links → **4**, mit **4** verschiedenen Ankertexten: „x-zeit", „der x-zeit-modus", „zeitversetzte fälligkeiten", „fälligkeitszeitpunkt als x+n"
- [x] JSON-LD valide, `datePublished: 2026-08-04` gesetzt
- [x] `scripts/check-internal-links.mjs` grün (315 Links, 0 Verstöße)
- [x] Floskel-Denylist grün (`scripts/check-content-quality.mjs`: 28 Seiten, 0 Verstöße)
- [x] Abschnitt „Fachlich zu prüfen" vorhanden

## Wie zu prüfen

```bash
npm ci && npm run build
node scripts/check-content-quality.mjs
node scripts/check-internal-links.mjs
npx vitest run
npx playwright test
```

Grün gelaufen: Build, Lint, **1184** Unit-Tests, **316** Playwright-Tests,
`links:check`, `content:check`.

Sichtprüfung: `npm run serve`, dann http://127.0.0.1:3000/x-zeit/ – Brotkrumen führen
über `Wissen › Funkübungen planen und durchführen`, die Seitenleiste zeigt die Seite in
ihrer Kategorie.

Titel 53 Zeichen, Description 153 Zeichen, 8 KB gzip gegen ein Budget von 120 KB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
