### PR TITLE
seo(AP-08): mache den Funkspruch-Bestand indexierbar

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -159,13 +159,21 @@ Marketing-Site und App, Ratgeber-Artikel unter `/ratgeber/`, strukturierte Daten
 FAQPage, sichtbare Aktualisierungsdaten.
 
 Eigene, belegbare Vorteile: kostenlos, ohne Anmeldung, ohne Installation, Open Source,
-über 1.800 Funksprüche in `assets/funksprueche/` (am 2026-08-03 exakt 3.683 nicht leere
-Zeilen). Die Zahl ändert sich mit jeder Pflege der Vorlagen, daher vor dem Zitieren neu
-zählen statt diesen Stand zu übernehmen:
+ein gewachsener Bestand echter Übungsfunksprüche in `assets/funksprueche/`.
+
+**Die Anzahl nicht von Hand zitieren.** Seit AP-08 kommt sie aus dem gezählten Bestand:
+`ANZAHL_GESAMT` (alle Vorlagen, also was der Generator verteilt) und `ANZAHL_ARCHIV`
+(nur das öffentliche Archiv) aus `scripts/lib/funkspruch-bestand.mjs`. Im Fließtext der
+Seiten stehen die Platzhalter `{{FUNKSPRUECHE_GESAMT}}` und `{{FUNKSPRUECHE_ARCHIV}}`,
+die der Build auflöst. Ein Test verbietet die früher verstreute Zahl „1.800" domainweit.
 
 ```
-cat assets/funksprueche/*.txt | grep -cve '^[[:space:]]*$'
+node -e 'import("./scripts/lib/funkspruch-bestand.mjs").then(m => console.log(m.ANZAHL_GESAMT, m.ANZAHL_ARCHIV))'
 ```
+
+Am 2026-08-04 sind das 3.684 und 2.024. **Nicht über `cat *.txt | grep -c` zählen** – das
+Ergebnis ist um eins zu niedrig, weil `nachrichten_thw_melle.txt` ohne Zeilenumbruch endet
+und `cat` ihre letzte Zeile mit der ersten der Folgedatei verklebt.
 
 Diese Punkte in Inhalten sichtbar machen, ohne den Wettbewerber abzuwerten oder unbelegte
 Behauptungen über ihn aufzustellen. Performance-Vergleiche nur mit selbst gemessenen,

--- a/e2e/funkspruch-archiv.spec.ts
+++ b/e2e/funkspruch-archiv.spec.ts
@@ -1,0 +1,148 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { expect, test } from "@playwright/test";
+
+import { ARCHIV_VORLAGEN } from "../scripts/lib/funkspruch-daten.mjs";
+
+// Playwright lädt die Spezifikationen als ES-Module; __dirname gibt es dort nicht.
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+interface Vorlage { datei: string; slug: string; name: string }
+const vorlagen = ARCHIV_VORLAGEN as unknown as Vorlage[];
+
+const zeilenDerQuelle = (datei: string): string[] =>
+    readFileSync(path.join(ROOT, "assets", "funksprueche", datei), "utf8")
+        .split(/\r?\n/)
+        .map(zeile => zeile.trim())
+        .filter(zeile => zeile !== "");
+
+/** Kleinste Archivvorlage – hält den Round-Trip-Test schnell. */
+const kleinste = [...vorlagen]
+    .sort((a, b) => zeilenDerQuelle(a.datei).length - zeilenDerQuelle(b.datei).length)[0]!;
+
+test.describe("Archiv ohne JavaScript", () => {
+    // Der entscheidende Punkt des Arbeitspakets: der Bestand steht im
+    // ausgelieferten HTML, nicht in einem nachgeladenen Datensatz.
+    test.use({ javaScriptEnabled: false });
+
+    for (const vorlage of vorlagen) {
+        test(`@seo /funksprueche/vorlage/${vorlage.slug}/ zeigt alle Funksprüche ohne JavaScript`, async ({ page }) => {
+            await page.goto(`/funksprueche/vorlage/${vorlage.slug}/`);
+
+            const zeilen = zeilenDerQuelle(vorlage.datei);
+            const eintraege = page.locator('[data-testid="funkspruch-liste"] > li');
+            await expect(eintraege).toHaveCount(zeilen.length);
+
+            // Erster, mittlerer und letzter Eintrag im sichtbaren Text: eine
+            // Stichprobe über die ganze Liste, ohne 752 Zusicherungen.
+            const sichtbar = (await page.locator("body").innerText()).replace(/\s+/g, " ");
+            for (const index of [0, Math.floor(zeilen.length / 2), zeilen.length - 1]) {
+                expect(sichtbar, `Funkspruch ${index + 1} fehlt im sichtbaren Text`)
+                    .toContain(zeilen[index]!.replace(/\s+/g, " "));
+            }
+        });
+    }
+
+    test("@seo die Übersichtsseite nennt jede Vorlage mit ihrer Anzahl", async ({ page }) => {
+        await page.goto("/funksprueche/");
+        const tabelle = page.getByTestId("vorlagen-tabelle");
+        await expect(tabelle).toBeVisible();
+
+        for (const vorlage of vorlagen) {
+            const zeile = tabelle.locator("tr", { hasText: vorlage.name }).first();
+            await expect(zeile).toContainText(String(zeilenDerQuelle(vorlage.datei).length));
+            await expect(zeile.locator("a")).toHaveAttribute(
+                "href", `../funksprueche/vorlage/${vorlage.slug}/`
+            );
+        }
+    });
+
+    test("@seo die humorvolle Vorlage ist genannt, aber nicht verlinkt", async ({ page }) => {
+        await page.goto("/funksprueche/");
+        const zeile = page.getByTestId("vorlagen-tabelle").locator("tr", { hasText: "Humorvolle Lagen" });
+        await expect(zeile).toContainText("nur im Generator");
+        await expect(zeile.locator("a")).toHaveCount(0);
+    });
+});
+
+test.describe("Filter über der Liste", () => {
+    test("@seo filtert die Liste im Browser, ohne Einträge zu entfernen", async ({ page }) => {
+        await page.goto(`/funksprueche/vorlage/${kleinste.slug}/`);
+
+        const eintraege = page.locator('[data-testid="funkspruch-liste"] > li');
+        const gesamt = zeilenDerQuelle(kleinste.datei).length;
+        await expect(eintraege).toHaveCount(gesamt);
+
+        const suchbegriff = zeilenDerQuelle(kleinste.datei)[0]!.split(/\s+/)[0]!;
+        await page.locator("#funkspruchSuche").fill(suchbegriff);
+
+        // Gefiltert wird über hidden – die Einträge bleiben im DOM und damit
+        // auch für einen Crawler ohne Skriptausführung vorhanden.
+        await expect(eintraege).toHaveCount(gesamt);
+        const sichtbare = await eintraege.evaluateAll(
+            liste => liste.filter(li => !(li as HTMLElement).hidden).length
+        );
+        expect(sichtbare).toBeGreaterThan(0);
+        expect(sichtbare).toBeLessThan(gesamt);
+        await expect(page.locator("#funkspruchTreffer")).toContainText("von");
+    });
+});
+
+test.describe("Download und Wiedereinlesen im Generator", () => {
+    for (const vorlage of vorlagen) {
+        test(`@seo Download für ${vorlage.slug} entspricht der Quelldatei`, async ({ request }) => {
+            const antwort = await request.get(`/assets/funksprueche-${vorlage.slug}.txt`);
+            expect(antwort.status()).toBe(200);
+
+            const inhalt = await antwort.text();
+            const zeilen = inhalt.split("\n");
+            expect(zeilen.pop()).toBe("");
+            expect(zeilen).toEqual(zeilenDerQuelle(vorlage.datei));
+        });
+    }
+
+    test("@seo die heruntergeladene Datei lässt sich im Generator wieder einlesen", async ({ page, request }) => {
+        const inhalt = await (await request.get(`/assets/funksprueche-${kleinste.slug}.txt`)).text();
+
+        await page.goto("/");
+
+        // Zwei Funkstellen genügen für den Nachweis, dass die Datei gelesen wird.
+        // Die Teilnehmertabelle bringt Zeilen mit, deshalb erst auffüllen, dann
+        // alle vorhandenen Felder belegen – sonst bleiben leere Namen stehen.
+        const namen = ["Heros Beispielstadt 11/11", "Heros Beispielstadt 22/22"];
+        const felder = page.locator("#teilnehmer-body .teilnehmer-input");
+        while ((await felder.count()) < namen.length) {
+            await page.locator("#addTeilnehmerBtn").click();
+        }
+        const anzahlFelder = await felder.count();
+        for (let i = 0; i < anzahlFelder; i++) {
+            await felder.nth(i).fill(namen[i] ?? `Heros Beispielstadt 9${i}/9${i}`);
+        }
+        await page.locator("#nameDerUebung").fill("Archiv-Round-Trip");
+        await page.locator("#spruecheProTeilnehmer").fill("3");
+
+        await page.locator("#optionUpload").check();
+        await page.locator("#funksprueche").setInputFiles({
+            name: `funksprueche-${kleinste.slug}.txt`,
+            mimeType: "text/plain",
+            buffer: Buffer.from(inhalt, "utf8")
+        });
+
+        await page.locator("#startUebungBtn").click();
+
+        // Die Übung entsteht: ohne lesbare Datei bliebe der Nachrichtenpool leer
+        // und die Generierung käme nicht bis zu den Links.
+        await expect(page.locator("#uebung-links")).toBeVisible();
+        await expect(
+            page.locator("#links-teilnehmer-container .generator-link-row[data-link-type='teilnehmer']")
+        ).toHaveCount(anzahlFelder);
+
+        // Drei Sprüche je Funkstelle – die Statuszeile zählt, was aus der
+        // hochgeladenen Datei verteilt wurde.
+        const anzahl = Number(await page.locator("#statusNachrichtenCount").textContent());
+        expect(anzahl, "keine Nachrichten aus der hochgeladenen Datei")
+            .toBeGreaterThanOrEqual(3 * anzahlFelder);
+    });
+});

--- a/scripts/check-content-quality.mjs
+++ b/scripts/check-content-quality.mjs
@@ -45,7 +45,21 @@ function redaktionell(html) {
  * denn sie sind echter Seiteninhalt.
  */
 function prosa(html) {
-    return redaktionell(html).replace(/<table[\s\S]*?<\/table>/gi, " ");
+    return ohneListe(redaktionell(html)).replace(/<table[\s\S]*?<\/table>/gi, " ");
+}
+
+/**
+ * Ohne die Funkspruch-Liste (AP-08). Die Einträge sind wörtlich zitiertes
+ * Quellmaterial aus den Übungsvorlagen, kein redaktioneller Text. Sie als
+ * Prosa zu messen wäre in zwei Richtungen falsch: 462 Meldungen ohne Satzzeichen
+ * ergeben einen Satz mit 124 Wörtern, und ein Funkspruch, der „nicht nur“
+ * enthält, wäre ein Floskel-Verstoß, den man nur durch Fälschen des Zitats
+ * beheben könnte. Für die Wortzahl zählt die Liste weiter mit.
+ */
+function ohneListe(html) {
+    return html
+        .replace(/<ol[^>]*class="[^"]*funkspruch-liste[^"]*"[\s\S]*?<\/ol>/gi, " ")
+        .replace(/<div[^>]*class="[^"]*funkspruch-filter[^"]*"[\s\S]*?<\/div>\s*<\/div>/gi, " ");
 }
 
 async function leseSeite(page) {
@@ -58,6 +72,10 @@ async function leseSeite(page) {
         titel: (html.match(/<title>([^<]*)<\/title>/i) ?? ["", ""])[1],
         description: (html.match(/<meta name="description" content="([^"]*)"/i) ?? ["", ""])[1],
         woerter: zaehleWoerter(plainText(inhalt)),
+        // Eigener Text neben der Liste – nur so lässt sich die Substanz einer
+        // Archivseite prüfen, deren Wortzahl sonst allein aus Zitaten besteht.
+        archiv: page.archiv === true,
+        eigeneWoerter: zaehleWoerter(plainText(ohneListe(inhalt))),
         text: plainText(prosa(html)),
         absaetze: [...inhalt.matchAll(/<p[^>]*>([\s\S]*?)<\/p>/gi)].map(treffer => plainText(treffer[1])),
         ankerZiele: [...html.matchAll(/data-testid="inhaltsverzeichnis"[\s\S]*?<\/nav>/gi)]
@@ -65,6 +83,7 @@ async function leseSeite(page) {
         ankerVorhanden: [...html.matchAll(/\bid="([^"]+)"/g)].map(treffer => treffer[1]),
         // gzip: das ist die tatsächlich übertragene Größe.
         transferBytes: gzipSync(Buffer.from(html, "utf8")).length,
+        roheBytes: Buffer.byteLength(html, "utf8"),
         hatMetazeile: html.includes('data-testid="aktualisiert-am"'),
         hatKurzGesagt: html.includes('data-testid="kurz-gesagt"'),
         // /faq/ trägt die Fragen im eigenen Markup, ohne injizierten Block:

--- a/scripts/lib/content-quality.mjs
+++ b/scripts/lib/content-quality.mjs
@@ -10,9 +10,18 @@ export const GRENZEN = {
     descMin: 140,
     descMax: 160,
     woerterMin: 800,
+    // Archivseiten (AP-08) tragen ihre Substanz in der Liste. Geprüft wird
+    // deshalb zusätzlich der eigene Text: eine Liste mit 750 Funksprüchen und
+    // zwei Sätzen Einleitung wäre formal lang und inhaltlich leer.
+    eigeneWoerterMin: 300,
     satzlaengeMax: 20,
     absatzMax: 120,
-    transferMaxBytes: 120 * 1024
+    transferMaxBytes: 120 * 1024,
+    // Unkomprimierte Seitengröße. Übertragen wird gzip, aber die rohe Größe
+    // bestimmt, wie viel ein Parser aufbauen muss – und AP-08 zieht die Grenze
+    // ausdrücklich bei 300 KB. Ohne diese Regel wäre die größte Archivseite
+    // unbemerkt darüber gewachsen (sie lag bei 333 KB).
+    roheBytesMax: 300 * 1024
 };
 
 /**
@@ -104,6 +113,11 @@ export function pruefeSeite(seite, grenzen = GRENZEN) {
         melde("zu-kurz", `${seite.woerter} Wörter (Ziel ${ziel})`);
     }
 
+    if (seite.archiv && (seite.eigeneWoerter ?? 0) < grenzen.eigeneWoerterMin) {
+        melde("zu-wenig-eigener-text",
+            `${seite.eigeneWoerter ?? 0} Wörter eigener Text neben der Liste (mindestens ${grenzen.eigeneWoerterMin})`);
+    }
+
     for (const floskel of findeFloskeln(seite.text)) {
         melde("floskel", `enthält „${floskel}“`);
     }
@@ -149,6 +163,11 @@ export function pruefeSeite(seite, grenzen = GRENZEN) {
 
     if ((seite.transferBytes ?? 0) > grenzen.transferMaxBytes) {
         melde("zu-gross", `${Math.round(seite.transferBytes / 1024)} KB (höchstens ${grenzen.transferMaxBytes / 1024} KB)`);
+    }
+
+    if ((seite.roheBytes ?? 0) > grenzen.roheBytesMax) {
+        melde("zu-viel-markup",
+            `${Math.round(seite.roheBytes / 1024)} KB unkomprimiert (höchstens ${grenzen.roheBytesMax / 1024} KB)`);
     }
 
     return verstoesse;

--- a/scripts/lib/funkspruch-bestand.mjs
+++ b/scripts/lib/funkspruch-bestand.mjs
@@ -1,0 +1,44 @@
+// Einlesen des Funkspruch-Bestands zur Buildzeit (AP-08).
+//
+// Synchron und beim Import, damit die Anzahl als echte Konstante zur Verfügung
+// steht: site-pages.mjs braucht sie in Template-Strings für „Kurz gesagt“ und
+// FAQ-Antworten, und dort ist kein await möglich.
+//
+// Absichtlich getrennt von funkspruch-daten.mjs: dort stehen die reinen Regeln,
+// hier der Dateizugriff. Nur so kann der Test die Regeln mit synthetischem Text
+// prüfen, ohne 350 KB Vorlagen zu laden.
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { baueBestand, deutscheZahl, VORLAGEN } from "./funkspruch-daten.mjs";
+
+const wurzel = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
+export const VORLAGEN_VERZEICHNIS = path.join(wurzel, "assets", "funksprueche");
+
+const inhalte = {};
+for (const vorlage of VORLAGEN) {
+    inhalte[vorlage.datei] = readFileSync(path.join(VORLAGEN_VERZEICHNIS, vorlage.datei), "utf8");
+}
+
+export const BESTAND = baueBestand(inhalte);
+
+/**
+ * Zwei Zahlen, die nicht verwechselt werden dürfen:
+ *
+ * ANZAHL_GESAMT – was der Generator verteilt, also alle Vorlagen. Das ist die
+ *   Zahl für Aussagen über den Umfang der Anwendung.
+ * ANZAHL_ARCHIV – was das öffentliche Archiv zeigt. Kleiner, weil die
+ *   humorvolle Vorlage nicht veröffentlicht wird (siehe VORLAGEN).
+ */
+export const ANZAHL_GESAMT = BESTAND.anzahlGesamt;
+export const ANZAHL_ARCHIV = BESTAND.anzahlArchiv;
+
+export const ANZAHL_GESAMT_TEXT = deutscheZahl(ANZAHL_GESAMT);
+export const ANZAHL_ARCHIV_TEXT = deutscheZahl(ANZAHL_ARCHIV);
+
+/** Einträge einer Vorlage, leer wenn der Slug unbekannt ist. */
+export function funkspruecheDerVorlage(slug) {
+    return BESTAND.nachVorlage.get(slug) ?? [];
+}

--- a/scripts/lib/funkspruch-daten.mjs
+++ b/scripts/lib/funkspruch-daten.mjs
@@ -1,0 +1,223 @@
+// Strukturierung des Funkspruch-Bestands (AP-08).
+//
+// Reine Funktionen ohne Datei- und Netzzugriff: das Einlesen macht
+// lib/funkspruch-bestand.mjs. So lässt sich jede Regel mit synthetischem Text
+// prüfen, ohne 350 KB Vorlagen zu laden.
+//
+// Grundsatz für alle Ableitungen hier: nur was aus Dateiname oder Text
+// nachweisbar folgt. Wo das nicht reicht, steht "allgemein" – lieber eine
+// ehrliche Sammelkategorie als eine geratene Zuordnung.
+
+import { createHash } from "node:crypto";
+
+/**
+ * Die Vorlagen des Bestands, eine je Datei unter assets/funksprueche/.
+ *
+ * `organisation` und `schwierigkeit` stehen hier, weil sie sich aus dem
+ * Dateinamen ergeben und nicht aus dem einzelnen Spruch: "nachrichten_thw_*"
+ * ist THW-Material, "*_einfach" ist als einfache Stufe benannt.
+ *
+ * `imArchiv: false` nimmt eine Vorlage aus dem öffentlichen Archiv, ohne sie
+ * dem Generator zu entziehen. Die Dateien bleiben unverändert im Repo und in
+ * der Anwendung auswählbar.
+ */
+export const VORLAGEN = [
+    {
+        datei: "funksprueche_grundausbildung_einfach.txt",
+        slug: "grundausbildung-einfach",
+        name: "Grundausbildung, einfache Nachrichten",
+        organisation: ["allgemein"],
+        schwierigkeit: "einfach",
+        imArchiv: true
+    },
+    {
+        datei: "nachrichten_thw_essen.txt",
+        slug: "thw-essen",
+        name: "THW Essen",
+        organisation: ["thw"],
+        imArchiv: true
+    },
+    {
+        datei: "nachrichten_thw_leer.txt",
+        slug: "thw-leer",
+        name: "THW Leer",
+        organisation: ["thw"],
+        imArchiv: true
+    },
+    {
+        datei: "nachrichten_thw_lehrte.txt",
+        slug: "thw-lehrte",
+        name: "THW Lehrte",
+        organisation: ["thw"],
+        imArchiv: true
+    },
+    {
+        datei: "nachrichten_thw_melle.txt",
+        slug: "thw-melle",
+        name: "THW Melle",
+        organisation: ["thw"],
+        imArchiv: true
+    },
+    {
+        datei: "nachrichten_thw_saarstedt.txt",
+        slug: "thw-saarstedt",
+        name: "THW Saarstedt",
+        organisation: ["thw"],
+        imArchiv: true
+    },
+    {
+        datei: "funksprueche_lustig_kreativ.txt",
+        slug: "lustig-kreativ",
+        name: "Humorvolle Lagen",
+        organisation: ["allgemein"],
+        schwierigkeit: "einfach",
+        // Bewusst nicht im öffentlichen Archiv: die Vorlage nennt fremde Marken
+        // und Figuren wörtlich. Sie in der Anwendung für Übungs-PDFs zu nutzen
+        // ist etwas anderes, als sie als durchsuchbares Archiv mit Download auf
+        // der eigenen Domain zu veröffentlichen. Im Generator bleibt sie wählbar.
+        imArchiv: false,
+        grund: "nennt fremde Marken und Figuren wörtlich"
+    }
+];
+
+/** Vorlagen des öffentlichen Archivs, in Registry-Reihenfolge. */
+export const ARCHIV_VORLAGEN = VORLAGEN.filter(vorlage => vorlage.imArchiv);
+
+export function vorlageFuerSlug(slug) {
+    return VORLAGEN.find(vorlage => vorlage.slug === slug);
+}
+
+/**
+ * Stabile Kennung eines Funkspruchs: die ersten 12 Hex-Zeichen des SHA-256 über
+ * den Text. Zwei Builds mit gleichem Text liefern dieselbe Kennung, und ein
+ * umsortierter oder umbenannter Bestand verschiebt keine Anker.
+ */
+export function funkspruchId(text) {
+    return createHash("sha256").update(String(text), "utf8").digest("hex").slice(0, 12);
+}
+
+/**
+ * Kategorien in Prüfreihenfolge – die erste zutreffende Regel gewinnt.
+ *
+ * Die Muster sind absichtlich eng gefasst. Ein weiter Ausdruck wie
+ * /anforder|benötig|material/ zieht über 500 Sprüche in die
+ * Materialanforderung, darunter Lagemeldungen, die das Wort nur nebenbei
+ * enthalten. Eine falsche Kategorie ist schlechter als keine, deshalb landet
+ * alles Unklare in "allgemein".
+ */
+export const KATEGORIE_REGELN = [
+    ["staerkemeldung", "Stärkemeldung", /\bStärke:?\s*\d|\bStärkemeldung\b|\bMannschaftsstärke\b/],
+    ["unwetter-hochwasser", "Unwetter und Hochwasser", /überflut|Überschwemmung|Hochwasser|\bPegel\b|\bDeich|Sandsäck|Starkregen|Unwetter|Sturmschaden|umgestürzt/i],
+    ["brandeinsatz", "Brandeinsatz", /\bBrand\b|\bbrennt\b|Löschzug|Löschwasser|Brandbekämpfung/],
+    ["sanitaetsdienst", "Sanitätsdienst", /Verletzt|verletzte|Verbandmaterial|Sanität|Rettungswagen|Notarzt|\bBHP\b|Medikament/],
+    ["technische-hilfeleistung", "Technische Hilfeleistung", /\bBergung\b|\bbergen\b|geborgen|Abstütz|abstütz|Verschütt|Räumung|Trennschleif|Hebekissen/],
+    ["erkundung", "Erkundung", /\bErkund/],
+    ["logistik", "Logistik", /Transport|Verpflegung|Kraftstoff|Betankung|Stromerzeuger|Trinkwasser|Pumpanlage/],
+    ["personalmeldung", "Personalmeldung", /Ablösung|ablösen|Dienstschluss|Voralarm/],
+    ["materialanforderung", "Materialanforderung", /\banfordern\b|angefordert|\bAnforderung\b|\berbitten\b/],
+    ["uebungsorganisation", "Übungsorganisation", /\bÜbung\b|Funkprobe|Sprechprobe|Lösungswort|Funkkanal/],
+    ["standortmeldung", "Standortmeldung", /\bStandort\b|Einsatzstelle erreicht|Treffpunkt erreicht/]
+];
+
+export const KATEGORIE_ALLGEMEIN = { key: "allgemein", name: "Allgemeiner Funkverkehr" };
+
+/** Alle Kategorien inklusive der Sammelkategorie, für Filter und Auswertung. */
+export const KATEGORIEN = [
+    ...KATEGORIE_REGELN.map(([key, name]) => ({ key, name })),
+    KATEGORIE_ALLGEMEIN
+];
+
+export function kategorieFuer(text) {
+    const treffer = KATEGORIE_REGELN.find(([, , muster]) => muster.test(text));
+    return treffer ? treffer[0] : KATEGORIE_ALLGEMEIN.key;
+}
+
+export function kategorieName(key) {
+    return KATEGORIEN.find(kategorie => kategorie.key === key)?.name ?? key;
+}
+
+/**
+ * Schwierigkeit aus der Textlänge, weil die Mitschrift den Aufwand bestimmt:
+ * Wer 300 Zeichen aufnimmt, schreibt bei etwa einem Zeichen je Sekunde fünf
+ * Minuten. Trägt die Vorlage schon eine Stufe im Namen, gilt die.
+ */
+export const SCHWIERIGKEIT_GRENZEN = { einfachBis: 80, schwerAb: 180 };
+
+export function schwierigkeitFuer(text, vorlage = {}) {
+    if (vorlage.schwierigkeit) return vorlage.schwierigkeit;
+    const zeichen = String(text).length;
+    if (zeichen <= SCHWIERIGKEIT_GRENZEN.einfachBis) return "einfach";
+    if (zeichen >= SCHWIERIGKEIT_GRENZEN.schwerAb) return "schwer";
+    return "mittel";
+}
+
+/**
+ * Enthält der Spruch ein Wort in Großbuchstaben, ist er als Buchstabieraufgabe
+ * geeignet: Ortsnamen, Straßen und Codewörter stehen im Bestand durchgängig so.
+ */
+export function hatBuchstabieranteil(text) {
+    return /\p{Lu}{3,}/u.test(String(text));
+}
+
+/** Zeilen einer Vorlagendatei zu Einträgen. Leerzeilen fallen weg. */
+export function parseVorlage(vorlage, inhalt) {
+    return String(inhalt)
+        .split(/\r?\n/)
+        .map(zeile => zeile.trim())
+        .filter(zeile => zeile !== "")
+        .map(text => ({
+            id: funkspruchId(text),
+            text,
+            vorlage: vorlage.slug,
+            kategorie: kategorieFuer(text),
+            organisation: vorlage.organisation,
+            schwierigkeit: schwierigkeitFuer(text, vorlage),
+            buchstabieren: hatBuchstabieranteil(text),
+            zeichen: text.length
+        }));
+}
+
+/**
+ * Baut den vollständigen Bestand.
+ *
+ * `inhalte` ist ein Objekt { <dateiname>: <inhalt> }. Fehlt eine Datei aus
+ * VORLAGEN, wirft die Funktion: ein stillschweigend halber Bestand würde die
+ * überall ausgewiesene Anzahl falsch machen.
+ */
+export function baueBestand(inhalte) {
+    const alle = [];
+    for (const vorlage of VORLAGEN) {
+        const inhalt = inhalte[vorlage.datei];
+        if (inhalt === undefined) {
+            throw new Error(`Vorlage "${vorlage.datei}" fehlt – Bestand wäre unvollständig.`);
+        }
+        alle.push(...parseVorlage(vorlage, inhalt));
+    }
+
+    const archivSlugs = new Set(ARCHIV_VORLAGEN.map(vorlage => vorlage.slug));
+    const archiv = alle.filter(eintrag => archivSlugs.has(eintrag.vorlage));
+
+    const nachVorlage = new Map();
+    for (const vorlage of VORLAGEN) {
+        nachVorlage.set(vorlage.slug, alle.filter(eintrag => eintrag.vorlage === vorlage.slug));
+    }
+
+    const nachKategorie = new Map();
+    for (const kategorie of KATEGORIEN) {
+        nachKategorie.set(kategorie.key, archiv.filter(eintrag => eintrag.kategorie === kategorie.key));
+    }
+
+    return {
+        alle,
+        archiv,
+        nachVorlage,
+        nachKategorie,
+        anzahlGesamt: alle.length,
+        anzahlArchiv: archiv.length
+    };
+}
+
+/** Deutsche Tausendertrennung, damit die Zahl im Text lesbar bleibt. */
+export function deutscheZahl(wert) {
+    return new Intl.NumberFormat("de-DE").format(wert);
+}

--- a/scripts/lib/funkspruch-seiten.mjs
+++ b/scripts/lib/funkspruch-seiten.mjs
@@ -1,0 +1,153 @@
+// Markup und Downloads des Funkspruch-Archivs (AP-08).
+//
+// Reine Funktionen: die Einträge kommen als Argument herein, Dateien schreibt
+// postbuild-copy.mjs. Die vollständige Liste steht im ausgelieferten HTML –
+// der Filter unten ist eine Zutat, keine Voraussetzung.
+
+import { escapeHtml } from "./schema-graph.mjs";
+import { deutscheZahl, KATEGORIEN, kategorieName, VORLAGEN } from "./funkspruch-daten.mjs";
+import { relativerPfad } from "./navigation.mjs";
+
+/** Einsetzstellen in den Quellseiten unter src/pages/. */
+export const LISTE_PLATZHALTER = "<!-- AP-08:LISTE -->";
+export const VORLAGEN_PLATZHALTER = "<!-- AP-08:VORLAGEN -->";
+
+const STUFEN_NAME = { einfach: "einfach", mittel: "mittel", schwer: "schwer" };
+
+/**
+ * Die vollständige Liste als statisches HTML.
+ *
+ * Eine <ol> statt <ul>: die Nummer ist die Fundstelle, auf die sich in der
+ * Nachbesprechung verweisen lässt. Jeder Eintrag trägt seine stabile Kennung
+ * als id, damit ein einzelner Funkspruch verlinkbar ist, ohne dass es 2.000
+ * Detailseiten mit je einem Satz Inhalt gibt.
+ */
+export function renderFunkspruchListe(eintraege) {
+    // Markup je Eintrag knapp halten: bei 752 Einträgen kostet jedes gesparte
+    // Byte 752 Byte Seitengröße. Einrückung, eine Klasse auf jedem <li> und
+    // data-Attribute, die niemand ausliest, summierten sich auf über 60 KB –
+    // genug, um die größte Seite über die 300-KB-Grenze zu heben.
+    // Geblieben ist, was gebraucht wird: id als Anker, data-kategorie für den
+    // Filter. Stufe und Buchstabieranteil stehen sichtbar in der Merkmalzeile.
+    const zeilen = eintraege.map(eintrag => {
+        const merkmale = [
+            kategorieName(eintrag.kategorie),
+            STUFEN_NAME[eintrag.schwierigkeit] ?? eintrag.schwierigkeit,
+            `${eintrag.zeichen} Zeichen`
+        ];
+        if (eintrag.buchstabieren) merkmale.push("buchstabieren");
+
+        return `<li id="fs-${eintrag.id}" data-kategorie="${eintrag.kategorie}">`
+            + `<span class="funkspruch-text">${escapeHtml(eintrag.text)}</span>`
+            + `<span class="funkspruch-meta">${escapeHtml(merkmale.join(" · "))}</span></li>`;
+    }).join("\n");
+
+    return `            <ol class="funkspruch-liste" data-testid="funkspruch-liste">
+${zeilen}
+            </ol>`;
+}
+
+/**
+ * Filter über der Liste. Ohne JavaScript bleibt die Liste vollständig sichtbar;
+ * die Bedienelemente stehen dann ungenutzt da, richten aber keinen Schaden an.
+ */
+export function renderFilter(eintraege) {
+    const vorhandene = KATEGORIEN.filter(kategorie =>
+        eintraege.some(eintrag => eintrag.kategorie === kategorie.key));
+
+    const optionen = vorhandene.map(kategorie => {
+        const anzahl = eintraege.filter(eintrag => eintrag.kategorie === kategorie.key).length;
+        return `                        <option value="${kategorie.key}">`
+            + `${escapeHtml(kategorie.name)} (${anzahl})</option>`;
+    }).join("\n");
+
+    return `            <div class="funkspruch-filter" data-testid="funkspruch-filter">
+                <label class="form-label" for="funkspruchSuche">Im Bestand suchen</label>
+                <input type="search" class="form-control" id="funkspruchSuche"
+                       placeholder="Stichwort, Ort oder Straße" autocomplete="off">
+                <label class="form-label mt-2" for="funkspruchKategorie">Nach Art filtern</label>
+                <select class="form-select" id="funkspruchKategorie">
+                        <option value="">Alle Arten</option>
+${optionen}
+                </select>
+                <p class="small text-body-secondary mt-2 mb-0" id="funkspruchTreffer"
+                   aria-live="polite" data-gesamt="${eintraege.length}">${deutscheZahl(eintraege.length)} Funksprüche</p>
+            </div>`;
+}
+
+/**
+ * Das Filterskript. Gehört vor </body> und damit außerhalb von <main>:
+ * innerhalb würde sein Quelltext als Seiteninhalt mitgezählt und jede
+ * Lesbarkeitsmessung verfälschen.
+ */
+export const FILTER_SKRIPT = `<script>
+    // Filter über der vollständig ausgelieferten Liste. Läuft das Skript nicht,
+    // bleibt die Liste unverändert vollständig sichtbar.
+    (function () {
+        var suche = document.getElementById("funkspruchSuche");
+        var art = document.getElementById("funkspruchKategorie");
+        var treffer = document.getElementById("funkspruchTreffer");
+        var liste = document.querySelector(".funkspruch-liste");
+        if (!suche || !art || !liste || !treffer) { return; }
+        var eintraege = Array.prototype.slice.call(liste.children);
+        var gesamt = Number(treffer.getAttribute("data-gesamt"));
+        function anwenden() {
+            var begriff = suche.value.trim().toLowerCase();
+            var kategorie = art.value;
+            var sichtbar = 0;
+            for (var i = 0; i < eintraege.length; i++) {
+                var li = eintraege[i];
+                var passt = (kategorie === "" || li.getAttribute("data-kategorie") === kategorie)
+                    && (begriff === "" || li.textContent.toLowerCase().indexOf(begriff) !== -1);
+                li.hidden = !passt;
+                if (passt) { sichtbar++; }
+            }
+            treffer.textContent = sichtbar === gesamt
+                ? sichtbar.toLocaleString("de-DE") + " Funksprüche"
+                : sichtbar.toLocaleString("de-DE") + " von " + gesamt.toLocaleString("de-DE") + " Funksprüchen";
+        }
+        suche.addEventListener("input", anwenden);
+        art.addEventListener("change", anwenden);
+    })();
+</script>
+`;
+
+/**
+ * Der Download im Upload-Format des Generators: eine Nachricht je Zeile, sonst
+ * nichts. Keine Kopfzeile und kein Kommentar – der Upload liest jede nicht
+ * leere Zeile als Funkspruch, ein Hinweistext würde als Nachricht auftauchen.
+ */
+export function txtInhalt(eintraege) {
+    return `${eintraege.map(eintrag => eintrag.text).join("\n")}\n`;
+}
+
+export function downloadDateiname(vorlagenSlug) {
+    return `funksprueche-${vorlagenSlug}.txt`;
+}
+
+/** Übersicht aller Vorlagen mit Anzahl, für /funksprueche/. */
+export function renderVorlagenTabelle(bestand, vonSlug = "funksprueche") {
+    const zeilen = VORLAGEN.map(vorlage => {
+        const anzahl = (bestand.nachVorlage.get(vorlage.slug) ?? []).length;
+        const ziel = vorlage.imArchiv
+            ? `<a href="${relativerPfad(vonSlug, `funksprueche/vorlage/${vorlage.slug}`)}">`
+                + `${escapeHtml(vorlage.name)}</a>`
+            : `${escapeHtml(vorlage.name)} <span class="text-body-secondary">`
+                + `(nur im Generator, ${escapeHtml(vorlage.grund ?? "nicht im Archiv")})</span>`;
+        const organisation = vorlage.organisation.includes("thw") ? "THW" : "organisationsübergreifend";
+        return `                        <tr><td>${ziel}</td>`
+            + `<td class="text-end">${deutscheZahl(anzahl)}</td>`
+            + `<td>${organisation}</td></tr>`;
+    }).join("\n");
+
+    return `            <div class="table-responsive">
+                <table class="table table-sm align-middle" data-testid="vorlagen-tabelle">
+                    <thead>
+                        <tr><th scope="col">Vorlage</th><th scope="col" class="text-end">Funksprüche</th><th scope="col">Herkunft</th></tr>
+                    </thead>
+                    <tbody>
+${zeilen}
+                    </tbody>
+                </table>
+            </div>`;
+}

--- a/scripts/lib/navigation.mjs
+++ b/scripts/lib/navigation.mjs
@@ -12,9 +12,16 @@
 import { escapeHtml } from "./schema-graph.mjs";
 import { HUB_CATEGORIES, HUB_SLUG, MAIN_NAV, canonicalUrl, hubSeiten } from "../site-pages.mjs";
 
-/** Relativer Pfad von einer Seite zu einer anderen. */
+/**
+ * Relativer Pfad von einer Seite zu einer anderen.
+ *
+ * Die Tiefe folgt der Zahl der Slug-Segmente: /faq/ liegt eine Ebene unter der
+ * Wurzel, /funksprueche/vorlage/thw-lehrte/ drei. Ein festes "../" hätte die
+ * Archivseiten auf nicht existierende Pfade zeigen lassen.
+ */
 export function relativerPfad(vonSlug, zuSlug) {
-    const auf = vonSlug === "" ? "" : "../";
+    const tiefe = vonSlug === "" ? 0 : vonSlug.split("/").filter(Boolean).length;
+    const auf = "../".repeat(tiefe);
     return zuSlug === "" ? (auf || "./") : `${auf}${zuSlug}/`;
 }
 
@@ -68,7 +75,17 @@ export function breadcrumbFuer(page) {
     if (page.slug === "") return [];
 
     const pfad = [{ name: "Startseite", slug: "" }];
-    if (page.slug !== HUB_SLUG && page.hubCategory) {
+
+    // Seiten unterhalb einer anderen Seite (Funkspruch-Archiv, AP-08) tragen
+    // ihre Elternebene selbst. Sie ersetzt den Hub-Pfad, statt ihn zu ergänzen:
+    // die Brotkrume soll der URL folgen. Über hubCategory bleiben die Seiten
+    // trotzdem in Hub-Karten und Seitenleiste sichtbar.
+    const eltern = page.breadcrumbEltern ?? [];
+    for (const stufe of eltern) {
+        pfad.push({ name: stufe.name, slug: stufe.slug });
+    }
+
+    if (eltern.length === 0 && page.slug !== HUB_SLUG && page.hubCategory) {
         const kategorie = HUB_CATEGORIES.find(eintrag => eintrag.key === page.hubCategory);
         pfad.push({ name: "Wissen", slug: HUB_SLUG });
         if (kategorie) {

--- a/scripts/lib/render-page.mjs
+++ b/scripts/lib/render-page.mjs
@@ -9,6 +9,15 @@ import { HUB_CATEGORIES, HUB_SLUG, SITE_PAGES } from "../site-pages.mjs";
 import { deutschesDatum, nurDatum } from "./lastmod.mjs";
 import { buildGraph, escapeHtml, renderFaqHtml } from "./schema-graph.mjs";
 import {
+    FILTER_SKRIPT,
+    LISTE_PLATZHALTER,
+    VORLAGEN_PLATZHALTER,
+    renderFilter,
+    renderFunkspruchListe,
+    renderVorlagenTabelle
+} from "./funkspruch-seiten.mjs";
+import { deutscheZahl } from "./funkspruch-daten.mjs";
+import {
     relativerPfad,
     breadcrumbFuer,
     renderBreadcrumb,
@@ -38,7 +47,8 @@ export const FAQ_PLATZHALTER = "<!-- AP-02:FAQ -->";
  * FAQ-Fragen oder fehlender Description darf nicht durchlaufen.
  */
 export function renderPageWithStructuredData({
-    page, html: quelle, dateModified = null, beschreibungen = {}, alleSeiten = SITE_PAGES
+    page, html: quelle, dateModified = null, beschreibungen = {}, alleSeiten = SITE_PAGES,
+    bestand = null
 }) {
     const title = extractTitle(quelle);
     const description = extractMetaDescription(quelle);
@@ -61,10 +71,14 @@ export function renderPageWithStructuredData({
     // Globale Bausteine zuerst: Navigation, Brotkrumen und Footer werden
     // ersetzt, bevor FAQ-Block und Datumszeile daran verankert werden.
     let html = quelle;
+    html = ersetzeBestandszahlen(html, bestand);
     html = setzeHauptnavigation(html, page);
     html = ersetzeBreadcrumb(html, page);
     html = ersetzeFooter(html, page);
     html = setzeHubKarten(html, page, beschreibungen);
+    // Vor den Einleitungsblöcken: das Inhaltsverzeichnis zählt die Abschnitte
+    // der fertigen Seite, und die Liste bringt keine eigene h2 mit.
+    html = setzeFunkspruchInhalte(html, page, bestand);
 
     if (!page.faqFromPage && faq.length > 0) {
         const block = renderFaqHtml(faq);
@@ -80,8 +94,14 @@ export function renderPageWithStructuredData({
         }
     }
 
+    // Umfang der Sammlung für Archivseiten: die Zahl steht im ItemList-Knoten,
+    // die Einträge selbst bleiben im sichtbaren HTML (AP-08).
+    const collectionAnzahl = page.archivVorlage && bestand
+        ? (bestand.nachVorlage.get(page.archivVorlage) ?? []).length
+        : undefined;
+
     const graph = buildGraph({
-        page: { ...page, breadcrumb, faq },
+        page: { ...page, breadcrumb, faq, collectionAnzahl },
         title,
         description,
         dateModified,
@@ -104,6 +124,72 @@ export function renderPageWithStructuredData({
     return { html, graph, faq, terme, title, description, breadcrumb };
 }
 
+
+/**
+ * Setzt die Bestandszahlen in den Fließtext ein (AP-08, Punkt 5).
+ *
+ * Die Zahl steht an rund einem Dutzend Stellen auf der Domain. Als Platzhalter
+ * im Quelltext gepflegt kann sie nicht auseinanderlaufen: sie stammt immer aus
+ * dem gezählten Bestand. Ein unaufgelöster Platzhalter bricht den Build – eine
+ * ausgelieferte Seite mit „{{FUNKSPRUECHE_GESAMT}} Funksprüche“ wäre schlimmer
+ * als eine veraltete Zahl.
+ */
+export const BESTAND_PLATZHALTER = {
+    "{{FUNKSPRUECHE_GESAMT}}": bestand => deutscheZahl(bestand.anzahlGesamt),
+    "{{FUNKSPRUECHE_ARCHIV}}": bestand => deutscheZahl(bestand.anzahlArchiv)
+};
+
+export function ersetzeBestandszahlen(html, bestand) {
+    let ergebnis = html;
+    for (const [platzhalter, wert] of Object.entries(BESTAND_PLATZHALTER)) {
+        if (!ergebnis.includes(platzhalter)) continue;
+        if (!bestand) {
+            throw new Error(`Platzhalter ${platzhalter} gefunden, aber kein Bestand übergeben.`);
+        }
+        ergebnis = ergebnis.replaceAll(platzhalter, wert(bestand));
+    }
+    return ergebnis;
+}
+
+/**
+ * Setzt Funkspruch-Liste, Filter und Vorlagen-Übersicht ein (AP-08).
+ *
+ * Der Bestand kommt als Argument herein, damit diese Datei ohne Dateizugriff
+ * bleibt. Fehlt er, während eine Seite ihn braucht, wirft die Funktion: eine
+ * Archivseite mit leerem Platzhalter wäre eine ausgelieferte, leere Seite.
+ */
+export function setzeFunkspruchInhalte(html, page, bestand) {
+    const brauchtListe = html.includes(LISTE_PLATZHALTER);
+    const brauchtTabelle = html.includes(VORLAGEN_PLATZHALTER);
+    if (!brauchtListe && !brauchtTabelle) return html;
+
+    if (!bestand) {
+        throw new Error(`Seite "${page.slug}": Funkspruch-Bestand fehlt, Platzhalter nicht auflösbar.`);
+    }
+
+    let ergebnis = html;
+
+    if (brauchtTabelle) {
+        ergebnis = ergebnis.replace(VORLAGEN_PLATZHALTER, renderVorlagenTabelle(bestand, page.slug));
+    }
+
+    if (brauchtListe) {
+        const eintraege = bestand.nachVorlage.get(page.archivVorlage);
+        if (!eintraege || eintraege.length === 0) {
+            throw new Error(`Seite "${page.slug}": keine Funksprüche für Vorlage "${page.archivVorlage}".`);
+        }
+        ergebnis = ergebnis.replace(
+            LISTE_PLATZHALTER,
+            `${renderFilter(eintraege)}\n${renderFunkspruchListe(eintraege)}`
+        );
+        if (!ergebnis.includes("</body>")) {
+            throw new Error(`Seite "${page.slug}": kein </body> für das Filterskript gefunden.`);
+        }
+        ergebnis = ergebnis.replace("</body>", `${FILTER_SKRIPT}</body>`);
+    }
+
+    return ergebnis;
+}
 
 /** Grenze, ab der eine Seite ein Inhaltsverzeichnis bekommt (AP-06). */
 export const TOC_AB_H2 = 4;

--- a/scripts/lib/schema-graph.mjs
+++ b/scripts/lib/schema-graph.mjs
@@ -226,15 +226,16 @@ export function buildFaqPage({ page, dateModified }) {
 
 export function buildCollection({ page, title, description }) {
     const eintraege = page.collection ?? [];
-    if (eintraege.length === 0) return null;
-    return kompakt({
-        "@type": "CollectionPage",
-        "@id": nodeId(page.slug, "collection"),
-        mainEntityOfPage: { "@id": nodeId(page.slug, "webpage") },
-        name: title,
-        description,
-        inLanguage: "de",
-        mainEntity: {
+    const anzahl = page.collectionAnzahl ?? 0;
+    if (eintraege.length === 0 && anzahl === 0) return null;
+
+    // Große Sammlungen (Funkspruch-Archiv, AP-08) nennen nur ihren Umfang.
+    // 752 ListItem-Knoten wären ein Vielfaches des Seiteninhalts an Markup,
+    // ohne dass ein Auswerter mehr erfährt als aus der sichtbaren Liste –
+    // itemListElement ist bei ItemList nicht verlangt.
+    const mainEntity = eintraege.length === 0
+        ? { "@type": "ItemList", numberOfItems: anzahl }
+        : {
             "@type": "ItemList",
             numberOfItems: eintraege.length,
             itemListElement: eintraege.map((eintrag, index) => kompakt({
@@ -243,7 +244,16 @@ export function buildCollection({ page, title, description }) {
                 name: eintrag.name,
                 url: eintrag.slug === undefined ? eintrag.url : canonicalUrl(eintrag.slug)
             }))
-        }
+        };
+
+    return kompakt({
+        "@type": "CollectionPage",
+        "@id": nodeId(page.slug, "collection"),
+        mainEntityOfPage: { "@id": nodeId(page.slug, "webpage") },
+        name: title,
+        description,
+        inLanguage: "de",
+        mainEntity
     });
 }
 

--- a/scripts/postbuild-copy.mjs
+++ b/scripts/postbuild-copy.mjs
@@ -6,6 +6,9 @@ import { buildSitemap, SITEMAP_PAGES, SITE_PAGES, STATIC_SUBPAGES } from "./site
 import { renderPageWithStructuredData } from "./lib/render-page.mjs";
 import { createGitRunner, resolveLastmod } from "./lib/lastmod.mjs";
 import { ersterSatz, extractMetaDescription } from "./lib/page-metadata.mjs";
+import { ARCHIV_VORLAGEN } from "./lib/funkspruch-daten.mjs";
+import { BESTAND } from "./lib/funkspruch-bestand.mjs";
+import { downloadDateiname, txtInhalt } from "./lib/funkspruch-seiten.mjs";
 
 const execFileAsync = promisify(execFile);
 
@@ -123,9 +126,27 @@ async function withStructuredData(page, quelle) {
         page,
         html: quelle,
         dateModified: await lastmodFuerSeite(page),
-        beschreibungen
+        beschreibungen,
+        bestand: BESTAND
     });
     return html;
+}
+
+// Downloads des Funkspruch-Archivs (AP-08). Sie liegen unter dist/assets/,
+// damit sie wie die übrigen Downloads ausgeliefert werden und nicht mit einer
+// Seiten-URL kollidieren. Format ist exakt das Upload-Format des Generators,
+// also eine Nachricht je Zeile – so schließt sich der Kreis vom Fund über den
+// Download zurück in die eigene Übung.
+for (const vorlage of ARCHIV_VORLAGEN) {
+    const eintraege = BESTAND.nachVorlage.get(vorlage.slug) ?? [];
+    if (eintraege.length === 0) {
+        throw new Error(`Vorlage "${vorlage.slug}" ist im Archiv, hat aber keine Funksprüche.`);
+    }
+    await writeFile(
+        path.join(dist, "assets", downloadDateiname(vorlage.slug)),
+        txtInhalt(eintraege),
+        "utf8"
+    );
 }
 
 

--- a/scripts/site-pages.mjs
+++ b/scripts/site-pages.mjs
@@ -2,6 +2,8 @@
 // Quelle der Wahrheit für Build (postbuild-copy.mjs), Sitemap, strukturierte
 // Daten (lib/schema-graph.mjs) und SEO-Tests.
 
+import { ANZAHL_GESAMT_TEXT } from "./lib/funkspruch-bestand.mjs";
+
 export const SITE_URL = "https://sprechfunk-uebung.de";
 
 /**
@@ -64,7 +66,7 @@ export const SITE_PAGES = [
             },
             {
                 q: "Wie viele Funksprüche bringt die Anwendung mit?",
-                a: "Über 1.800 fertige Funksprüche in mehreren Vorlagen. Eigene Texte aus dem Ortsverband oder der eigenen Wache lassen sich zusätzlich hochladen."
+                a: `${ANZAHL_GESAMT_TEXT} fertige Funksprüche in mehreren Vorlagen. Eigene Texte aus dem Ortsverband oder der eigenen Wache lassen sich zusätzlich hochladen.`
             }
         ]
     },
@@ -192,7 +194,7 @@ export const SITE_PAGES = [
     },
     {
         slug: "funksprueche", source: "pages/funksprueche.html", sources: ["src/pages/funksprueche.html"],
-        kurzGesagt: "Der Generator bringt über 1.800 fertige Funksprüche in mehreren Vorlagen mit und verteilt sie automatisch auf die Teilnehmer. Die Vorlagen decken Einsatzlagen aus dem Katastrophenschutz und bewusst überzeichnete Lagen für Jugendgruppen ab. Eigene Texte lassen sich als Textdatei hochladen, eine Zeile je Funkspruch. Über Lösungswörter entstehen Buchstabieraufgaben.",
+        kurzGesagt: `Der Generator bringt ${ANZAHL_GESAMT_TEXT} fertige Funksprüche in mehreren Vorlagen mit und verteilt sie automatisch auf die Teilnehmer. Die Vorlagen decken Einsatzlagen aus dem Katastrophenschutz und bewusst überzeichnete Lagen für Jugendgruppen ab. Eigene Texte lassen sich als Textdatei hochladen, eine Zeile je Funkspruch. Über Lösungswörter entstehen Buchstabieraufgaben.`,
         related: ["funkuebung-szenarien", "buchstabiertafel", "funkuebung-vorlage"],
         label: "Funksprüche",
         hubCategory: "anwendung",
@@ -205,7 +207,7 @@ export const SITE_PAGES = [
         faq: [
             {
                 q: "Wie viele Funksprüche sind enthalten?",
-                a: "Über 1.800 fertige Funksprüche in mehreren Vorlagen. Sie werden automatisch auf die Teilnehmer verteilt."
+                a: `${ANZAHL_GESAMT_TEXT} fertige Funksprüche in mehreren Vorlagen. Sie werden automatisch auf die Teilnehmer verteilt.`
             },
             {
                 q: "Welche Vorlagen gibt es?",
@@ -218,6 +220,174 @@ export const SITE_PAGES = [
             {
                 q: "Lassen sich Buchstabieraufgaben einbauen?",
                 a: "Ja. Über Lösungswörter entstehen Aufgaben, bei denen die Teilnehmer nach der Buchstabiertafel buchstabieren müssen."
+            }
+        ]
+    },
+    {
+        slug: "funksprueche/vorlage/grundausbildung-einfach",
+        source: "pages/funksprueche-vorlage-grundausbildung-einfach.html",
+        sources: ["src/pages/funksprueche-vorlage-grundausbildung-einfach.html", "assets/funksprueche/funksprueche_grundausbildung_einfach.txt"],
+        archivVorlage: "grundausbildung-einfach",
+        breadcrumbEltern: [{ name: "Funksprüche", slug: "funksprueche" }],
+        kurzGesagt: "Diese Vorlage enthält 462 kurze Übungsnachrichten für die erste Funkübung nach dem Lehrgang. Die Texte sind knapp, damit Anruf, Anrufantwort und Bestätigung geübt werden und nicht das Mitschreiben. Sie eignen sich für Grundausbildung, Jugendgruppen und den Wiedereinstieg nach längerer Pause. Der Download lässt sich unverändert in den Generator laden.",
+        related: ["funksprueche", "funkuebung-vorlage", "funkuebung-planen"],
+        label: "Vorlage Grundausbildung",
+        hubCategory: "anwendung",
+        archiv: true,
+        schemaType: "CollectionPage", datePublished: "2026-08-04",
+        about: ["Funksprüche", "Übungstexte", "Vorlage Grundausbildung"],
+        faq: [
+            {
+                q: "Für wen ist diese Vorlage geeignet?",
+                a: "Für die erste Funkübung nach dem Lehrgang, für Jugendgruppen und für den Wiedereinstieg nach längerer Pause. Die Nachrichten sind kurz, damit das Verfahren im Mittelpunkt steht und nicht das Mitschreiben."
+            },
+            {
+                q: "Wie lang sind die Nachrichten?",
+                a: "Kurz: die Hälfte liegt unter 50 Zeichen. Ein vollständiger Verkehr dauert damit etwa 30 Sekunden statt zwei Minuten."
+            },
+            {
+                q: "Kann ich die Vorlage herunterladen und selbst nutzen?",
+                a: "Ja. Der Download ist eine Textdatei mit einer Nachricht je Zeile – genau das Format, das der Generator beim Upload liest. Die Nutzung steht unter der EUPL-1.2."
+            }
+        ]
+    },
+    {
+        slug: "funksprueche/vorlage/thw-essen",
+        source: "pages/funksprueche-vorlage-thw-essen.html",
+        sources: ["src/pages/funksprueche-vorlage-thw-essen.html", "assets/funksprueche/nachrichten_thw_essen.txt"],
+        archivVorlage: "thw-essen",
+        breadcrumbEltern: [{ name: "Funksprüche", slug: "funksprueche" }],
+        kurzGesagt: "Diese Vorlage enthält 92 Übungsnachrichten aus einer Hochwasserlage im Essener Stadtgebiet, ausgehend von einem Deichbruch an der Emscher. Der Schwerpunkt liegt auf Erkundungsaufträgen und der geordneten Rückmeldung. Mehrere Nachrichten üben Stärkemeldungen und Koordinatenangaben im UTM-Format. Mit 92 Einträgen reicht sie für einen Abend mit acht Funkstellen.",
+        related: ["funksprueche", "funkuebung-vorlage", "funkuebung-planen"],
+        label: "Vorlage THW Essen",
+        hubCategory: "anwendung",
+        archiv: true,
+        schemaType: "CollectionPage", datePublished: "2026-08-04",
+        about: ["Funksprüche", "Übungstexte", "Vorlage THW Essen"],
+        faq: [
+            {
+                q: "Woher stammen die Nachrichten dieser Vorlage?",
+                a: "Aus einer Übungslage des THW-Ortsverbands Essen zu einem Deichbruch an der Emscher. Die Straßennamen sind echte Orte im Essener Norden."
+            },
+            {
+                q: "Muss ich aus Essen sein, um die Vorlage zu nutzen?",
+                a: "Nein. Die Ortsangaben sind Buchstabierstoff, unabhängig davon, ob die Teilnehmer die Straßen kennen. Wer lokale Namen bevorzugt, lädt eine eigene Datei hoch."
+            },
+            {
+                q: "Was übt diese Vorlage besonders?",
+                a: "Erkundungsaufträge mit geordneter Rückmeldung, Stärkemeldungen in der üblichen Schreibweise und die Übermittlung von Koordinaten im UTM-Format."
+            }
+        ]
+    },
+    {
+        slug: "funksprueche/vorlage/thw-leer",
+        source: "pages/funksprueche-vorlage-thw-leer.html",
+        sources: ["src/pages/funksprueche-vorlage-thw-leer.html", "assets/funksprueche/nachrichten_thw_leer.txt"],
+        archivVorlage: "thw-leer",
+        breadcrumbEltern: [{ name: "Funksprüche", slug: "funksprueche" }],
+        kurzGesagt: "Diese Vorlage enthält 118 Übungsnachrichten aus einer Sturm- und Hochwasserlage in Ostfriesland. Sie ist als Flächenlage angelegt: viele kleine Einsatzstellen gleichzeitig statt einer großen. Typisch sind versperrte Landesstraßen, volle Keller und drohende Uferüberläufe mit Erkundungsauftrag. Damit übt sie vor allem das Priorisieren auf einem belegten Kanal.",
+        related: ["funksprueche", "funkuebung-vorlage", "funkuebung-planen"],
+        label: "Vorlage THW Leer",
+        hubCategory: "anwendung",
+        archiv: true,
+        schemaType: "CollectionPage", datePublished: "2026-08-04",
+        about: ["Funksprüche", "Übungstexte", "Vorlage THW Leer"],
+        faq: [
+            {
+                q: "Was unterscheidet eine Flächenlage von einer Einsatzlage?",
+                a: "Bei einer Flächenlage kommen einzelne Meldungen von vielen Orten, bei einer Einsatzlage viele Meldungen von einem Ort. Diese Vorlage ist der erste Fall und übt vor allem das Priorisieren."
+            },
+            {
+                q: "Wie viele Funkstellen trägt diese Vorlage?",
+                a: "118 Nachrichten reichen für einen Abend mit etwa zehn Funkstellen. Für längere Übungen lässt sie sich mit der Lehrte-Vorlage kombinieren."
+            },
+            {
+                q: "Braucht die Übung eine besetzte Führungsstelle?",
+                a: "Sie ist von Vorteil. Viele Meldungen ziehen eine Entscheidung nach sich, und eine Führungsstelle beantwortet Rückfragen statt nur mitzuschreiben."
+            }
+        ]
+    },
+    {
+        slug: "funksprueche/vorlage/thw-lehrte",
+        source: "pages/funksprueche-vorlage-thw-lehrte.html",
+        sources: ["src/pages/funksprueche-vorlage-thw-lehrte.html", "assets/funksprueche/nachrichten_thw_lehrte.txt"],
+        archivVorlage: "thw-lehrte",
+        breadcrumbEltern: [{ name: "Funksprüche", slug: "funksprueche" }],
+        kurzGesagt: "Mit 752 Übungsnachrichten ist dies die größte Vorlage des Bestands. Sie beschreibt eine ausgedehnte Unwetterlage im Raum Lehrte und Burgdorf mit überfluteten Straßenzügen, beschädigten Bahnanlagen und Versorgungsausfällen. Die Texte sind die längsten im Archiv und verlangen eine geordnete Mitschrift. Damit trägt sie auch eine mehrtägige Stabsrahmenübung.",
+        related: ["funksprueche", "funkuebung-vorlage", "funkuebung-planen"],
+        label: "Vorlage THW Lehrte",
+        hubCategory: "anwendung",
+        archiv: true,
+        schemaType: "CollectionPage", datePublished: "2026-08-04",
+        about: ["Funksprüche", "Übungstexte", "Vorlage THW Lehrte"],
+        faq: [
+            {
+                q: "Warum ist diese Vorlage die größte?",
+                a: "Sie beschreibt eine ausgedehnte Unwetterlage mit mehreren gleichzeitigen Schadensschwerpunkten. 752 Nachrichten tragen rund zehn Übungsabende ohne Wiederholung."
+            },
+            {
+                q: "Für welchen Ausbildungsstand ist sie geeignet?",
+                a: "Für erfahrene Sprechfunker und für Stabsrahmenübungen. Die Texte sind die längsten im Archiv und verlangen eine geordnete Mitschrift im Meldevordruck."
+            },
+            {
+                q: "Enthält die Vorlage Nachrichten für andere Organisationen?",
+                a: "Ja. Ein Teil spricht Feuerwehreinheiten und die zivile Versorgung an, etwa Apotheken und Trinkwassertransporte. Damit eignet sie sich für organisationsübergreifende Übungen."
+            }
+        ]
+    },
+    {
+        slug: "funksprueche/vorlage/thw-melle",
+        source: "pages/funksprueche-vorlage-thw-melle.html",
+        sources: ["src/pages/funksprueche-vorlage-thw-melle.html", "assets/funksprueche/nachrichten_thw_melle.txt"],
+        archivVorlage: "thw-melle",
+        breadcrumbEltern: [{ name: "Funksprüche", slug: "funksprueche" }],
+        kurzGesagt: "Diese Vorlage enthält 400 Übungsnachrichten mit der höchsten Fachdichte im Archiv, aus einer Hochwasserlage an der Weser. Typisch sind Pegelmeldungen, Behandlungsplätze, Einsatzabschnitte und Kanalzuweisungen. Die Nachrichten setzen Kenntnis der Abkürzungen voraus und richten sich an Führungskräfte. Für die Grundausbildung ist sie ausdrücklich nicht gedacht.",
+        related: ["funksprueche", "funkuebung-vorlage", "funkuebung-planen"],
+        label: "Vorlage THW Melle",
+        hubCategory: "anwendung",
+        archiv: true,
+        schemaType: "CollectionPage", datePublished: "2026-08-04",
+        about: ["Funksprüche", "Übungstexte", "Vorlage THW Melle"],
+        faq: [
+            {
+                q: "An wen richtet sich diese Vorlage?",
+                a: "An Führungskräfte und an eine Sprechfunkausbildung auf Führungsebene. Die Nachrichten setzen Kenntnis der Abkürzungen und Fachbegriffe voraus."
+            },
+            {
+                q: "Welche Meldearten kommen besonders häufig vor?",
+                a: "Pegelmeldungen, Anforderungen mit Zeitdruck, Kanalzuweisungen für Einsatzabschnitte und Stärkemeldungen mit Fahrzeugaufstellung."
+            },
+            {
+                q: "Eignet sich die Vorlage für die Grundausbildung?",
+                a: "Nein. Die Fachdichte ist zu hoch; Teilnehmer können die Nachricht korrekt aufnehmen und trotzdem nicht handeln. Für den Einstieg gibt es die Vorlage für die Grundausbildung."
+            }
+        ]
+    },
+    {
+        slug: "funksprueche/vorlage/thw-saarstedt",
+        source: "pages/funksprueche-vorlage-thw-saarstedt.html",
+        sources: ["src/pages/funksprueche-vorlage-thw-saarstedt.html", "assets/funksprueche/nachrichten_thw_saarstedt.txt"],
+        archivVorlage: "thw-saarstedt",
+        breadcrumbEltern: [{ name: "Funksprüche", slug: "funksprueche" }],
+        kurzGesagt: "Diese Vorlage enthält 200 kurze Übungsnachrichten, die fast alle einen Straßen- oder Ortsnamen in Großbuchstaben tragen. Sie ist damit die Buchstabier-Vorlage des Archivs und übt Standortmeldungen. Die Texte sind mit im Schnitt 62 Zeichen kurz, der Anspruch liegt allein im Namen. Für einen Abend mit Schwerpunkt Buchstabiertafel ist sie die erste Wahl.",
+        related: ["funksprueche", "funkuebung-vorlage", "funkuebung-planen"],
+        label: "Vorlage THW Saarstedt",
+        hubCategory: "anwendung",
+        archiv: true,
+        schemaType: "CollectionPage", datePublished: "2026-08-04",
+        about: ["Funksprüche", "Übungstexte", "Vorlage THW Saarstedt"],
+        faq: [
+            {
+                q: "Was macht diese Vorlage zur Buchstabier-Vorlage?",
+                a: "Fast jede der 200 Nachrichten trägt einen Straßen- oder Ortsnamen in Großbuchstaben. Damit kommt das Buchstabieren nach der Buchstabiertafel in jeder Nachricht vor statt nur gelegentlich."
+            },
+            {
+                q: "Wie lang sind die Nachrichten?",
+                a: "Kurz: im Schnitt 62 Zeichen. Der Aufwand liegt nicht in der Mitschrift, sondern im Buchstabieren des Namens."
+            },
+            {
+                q: "Lässt sich die Vorlage mit anderen mischen?",
+                a: "Ja, und das ist empfehlenswert. Zusammen mit einer Unwetterlage füllen die kurzen Standortmeldungen die Lücken zwischen langen Lagemeldungen."
             }
         ]
     },
@@ -342,7 +512,7 @@ export const SITE_PAGES = [
     },
     {
         slug: "funkuebung-vorlage", source: "pages/funkuebung-vorlage.html", sources: ["src/pages/funkuebung-vorlage.html"],
-        kurzGesagt: "Eine feste PDF-Vorlage ist nach wenigen Einsätzen verbraucht, weil alle in der Einheit die Funksprüche kennen. Der Generator erzeugt aus über 1.800 Übungstexten jedes Mal eine neue, vollständige Sprechfunkübung, zugeschnitten auf Teilnehmerzahl und Rufnamen. Enthalten sind die verteilten Funksprüche, Vordrucke und die Unterlagen für die Übungsleitung.",
+        kurzGesagt: `Eine feste PDF-Vorlage ist nach wenigen Einsätzen verbraucht, weil alle in der Einheit die Funksprüche kennen. Der Generator erzeugt aus ${ANZAHL_GESAMT_TEXT} Übungstexten jedes Mal eine neue, vollständige Sprechfunkübung, zugeschnitten auf Teilnehmerzahl und Rufnamen. Enthalten sind die verteilten Funksprüche, Vordrucke und die Unterlagen für die Übungsleitung.`,
         related: ["funksprueche", "funkuebung-planen", "meldevordruck"],
         label: "Funkübung Vorlage",
         hubCategory: "uebungen",
@@ -351,7 +521,7 @@ export const SITE_PAGES = [
         faq: [
             {
                 q: "Warum kein starres PDF als Vorlage?",
-                a: "Eine feste Vorlage ist nach wenigen Einsätzen verbraucht, weil alle in der Einheit die Funksprüche kennen. Der Generator erzeugt aus über 1.800 Übungstexten jedes Mal eine neue Übung."
+                a: `Eine feste Vorlage ist nach wenigen Einsätzen verbraucht, weil alle in der Einheit die Funksprüche kennen. Der Generator erzeugt aus ${ANZAHL_GESAMT_TEXT} Übungstexten jedes Mal eine neue Übung.`
             },
             {
                 q: "Was enthält die fertige Übung?",

--- a/seo/content-quality-report.md
+++ b/seo/content-quality-report.md
@@ -11,34 +11,40 @@ Inhaltsverzeichnis, Metazeile, Seitenleiste und Weiterlesen-Block sind abgezogen
 
 | Seite | Wörter | Ziel | Titel | Desc | gzip |
 | --- | ---: | ---: | ---: | ---: | ---: |
-| `/funkuebung-planen/` | 823 | 800 | 53 | 149 | 8 KB |
-| `/funkuebung-vorlage/` | 824 | 800 | 52 | 150 | 7 KB |
-| `/open-source/` | 826 | 800 | 53 | 150 | 7 KB |
+| `/funkuebung-planen/` | 822 | 800 | 53 | 149 | 8 KB |
+| `/open-source/` | 825 | 800 | 53 | 150 | 8 KB |
 | `/digitale-funkuebung/` | 826 | 800 | 51 | 152 | 7 KB |
-| `/funkuebung-katastrophenschutz/` | 827 | 800 | 50 | 149 | 7 KB |
 | `/meldevordruck/` | 831 | 800 | 51 | 150 | 7 KB |
-| `/funksprueche/` | 831 | 800 | 51 | 156 | 8 KB |
 | `/funkrufnamen-thw/` | 832 | 800 | 51 | 149 | 8 KB |
 | `/funkrufnamen/` | 846 | 800 | 55 | 155 | 8 KB |
-| `/wissen/` | 847 | 800 | 53 | 155 | 9 KB |
+| `/wissen/` | 847 | 800 | 53 | 155 | 10 KB |
 | `/faq/` | 854 | 800 | 53 | 149 | 8 KB |
-| `/funktionen/` | 862 | 800 | 53 | 153 | 8 KB |
+| `/funktionen/` | 861 | 800 | 53 | 153 | 8 KB |
 | `/verkehrsarten/` | 872 | 800 | 55 | 152 | 8 KB |
-| `/funkuebung-dienstabend/` | 917 | 900 | 52 | 153 | 8 KB |
-| `/betriebsworte/` | 950 | 800 | 56 | 155 | 8 KB |
+| `/funkuebung-vorlage/` | 882 | 800 | 52 | 150 | 8 KB |
+| `/funkuebung-katastrophenschutz/` | 884 | 800 | 50 | 149 | 8 KB |
+| `/funksprueche/` | 930 | 800 | 53 | 154 | 8 KB |
+| `/betriebsworte/` | 949 | 800 | 56 | 155 | 9 KB |
 | `/funkmeldesystem/` | 953 | 800 | 52 | 150 | 8 KB |
+| `/funkuebung-dienstabend/` | 984 | 900 | 52 | 153 | 8 KB |
 | `/antennen/` | 990 | 800 | 55 | 155 | 8 KB |
-| `/funkuebung-thw/` | 1012 | 1000 | 52 | 156 | 8 KB |
-| `/bos-funk/` | 1058 | 800 | 51 | 153 | 9 KB |
+| `/bos-funk/` | 1057 | 800 | 51 | 153 | 9 KB |
+| `/funkuebung-thw/` | 1094 | 1000 | 52 | 156 | 9 KB |
 | `/funkreichweite/` | 1097 | 800 | 51 | 156 | 9 KB |
-| `/funkuebung-feuerwehr/` | 1136 | 1100 | 51 | 156 | 8 KB |
+| `/funkuebung-feuerwehr/` | 1135 | 1100 | 51 | 156 | 9 KB |
 | `/uebungsfunkverkehr/` | 1155 | 800 | 52 | 155 | 9 KB |
-| `/regiebuch-funkuebung/` | 1159 | 1100 | 52 | 157 | 8 KB |
 | `/x-zeit/` | 1170 | 800 | 53 | 153 | 8 KB |
-| `/sprechfunk-regeln/` | 1173 | 800 | 54 | 147 | 9 KB |
-| `/buchstabiertafel/` | 1198 | 800 | 53 | 157 | 10 KB |
-| `/funkuebung-szenarien/` | 1220 | 1200 | 51 | 149 | 9 KB |
+| `/sprechfunk-regeln/` | 1172 | 800 | 54 | 147 | 9 KB |
+| `/regiebuch-funkuebung/` | 1221 | 1100 | 52 | 157 | 8 KB |
 | `/anleitung/` | 1262 | 800 | 51 | 154 | 10 KB |
+| `/buchstabiertafel/` | 1273 | 800 | 53 | 157 | 10 KB |
+| `/funkuebung-szenarien/` | 1291 | 1200 | 51 | 149 | 10 KB |
+| `/funksprueche/vorlage/thw-essen/` | 2172 | 800 | 53 | 155 | 15 KB |
+| `/funksprueche/vorlage/thw-leer/` | 2575 | 800 | 55 | 159 | 16 KB |
+| `/funksprueche/vorlage/thw-saarstedt/` | 2767 | 800 | 55 | 156 | 16 KB |
+| `/funksprueche/vorlage/grundausbildung-einfach/` | 5474 | 800 | 55 | 145 | 24 KB |
+| `/funksprueche/vorlage/thw-melle/` | 8347 | 800 | 55 | 159 | 36 KB |
+| `/funksprueche/vorlage/thw-lehrte/` | 14063 | 800 | 55 | 155 | 58 KB |
 
 ## Verstöße: 0
 

--- a/seo/internal-links-report.md
+++ b/seo/internal-links-report.md
@@ -11,9 +11,9 @@ auf jeder Seite gleich sind.
 
 ## Überblick
 
-- Seiten in der Registry: 31
-- davon Inhaltsseiten: 28
-- Fließtext-Links gesamt: 315
+- Seiten in der Registry: 37
+- davon Inhaltsseiten: 34
+- Fließtext-Links gesamt: 349
 - Verstöße: 0
 - Seiten ohne eingehenden Fließtext-Link: 0
 
@@ -25,31 +25,37 @@ Keine. Jede Inhaltsseite hat mindestens einen eingehenden Fließtext-Link.
 
 | Seite | eingehend | ausgehend |
 | --- | ---: | ---: |
-| `/meldevordruck/` | 27 | 5 |
-| `/regiebuch-funkuebung/` | 25 | 8 |
-| `/buchstabiertafel/` | 23 | 6 |
-| `/funksprueche/` | 23 | 4 |
+| `/meldevordruck/` | 29 | 5 |
+| `/buchstabiertafel/` | 25 | 7 |
+| `/regiebuch-funkuebung/` | 25 | 9 |
+| `/funksprueche/` | 23 | 10 |
 | `/sprechfunk-regeln/` | 18 | 19 |
 | `/anleitung/` | 16 | 13 |
 | `/funkuebung-planen/` | 14 | 17 |
 | `/bos-funk/` | 13 | 13 |
 | `/open-source/` | 13 | 6 |
-| `/funkuebung-dienstabend/` | 12 | 11 |
+| `/funkuebung-dienstabend/` | 12 | 12 |
 | `/digitale-funkuebung/` | 11 | 7 |
-| `/funkuebung-thw/` | 8 | 10 |
+| `/funkrufnamen/` | 9 | 13 |
+| `/funkuebung-thw/` | 8 | 15 |
 | `/betriebsworte/` | 8 | 12 |
-| `/funkrufnamen/` | 8 | 13 |
 | `/funkuebung-feuerwehr/` | 7 | 8 |
-| `/funkuebung-vorlage/` | 7 | 12 |
-| `/funkuebung-szenarien/` | 6 | 15 |
+| `/funkuebung-vorlage/` | 7 | 14 |
+| `/funkuebung-szenarien/` | 7 | 17 |
 | `/uebungsfunkverkehr/` | 6 | 12 |
 | `/funkreichweite/` | 6 | 14 |
+| `/x-zeit/` | 5 | 8 |
+| `/funksprueche/vorlage/thw-lehrte/` | 4 | 3 |
+| `/funksprueche/vorlage/thw-melle/` | 4 | 2 |
+| `/funkuebung-katastrophenschutz/` | 4 | 10 |
 | `/verkehrsarten/` | 4 | 12 |
 | `/antennen/` | 4 | 7 |
-| `/x-zeit/` | 4 | 8 |
 | `/faq/` | 4 | 11 |
 | `/funktionen/` | 3 | 21 |
-| `/funkuebung-katastrophenschutz/` | 3 | 8 |
+| `/funksprueche/vorlage/grundausbildung-einfach/` | 3 | 3 |
+| `/funksprueche/vorlage/thw-essen/` | 3 | 2 |
+| `/funksprueche/vorlage/thw-leer/` | 3 | 2 |
+| `/funksprueche/vorlage/thw-saarstedt/` | 3 | 2 |
 | `/funkrufnamen-thw/` | 3 | 11 |
 | `/funkmeldesystem/` | 3 | 13 |
 | `/wissen/` | 3 | 4 |
@@ -59,9 +65,9 @@ Keine. Jede Inhaltsseite hat mindestens einen eingehenden Fließtext-Link.
 | Ziel | Varianten | Ankertexte |
 | --- | ---: | --- |
 | `/meldevordruck/` | 8 | „druckvordrucke“, „lagemeldung“, „meldevordruck“, „meldevordruck und nachrichtenvordruck“, „meldevordrucke“, „nachrichtenvordruck“, „pdf-vordrucken“, „vordrucke“ |
-| `/regiebuch-funkuebung/` | 11 | „auswertung“, „live-cockpit“, „live-nachrichtenplan“, „live-übungsleitung“, „live-übungsleitung ansehen“, „nachrichtenplan“, „nachrichtenplan ansehen“, „regiebuch“, „regiebuch der übung“, „regiebuch mit live-übungsleitung“, „übungsleitung“ |
 | `/buchstabiertafel/` | 4 | „buchstabieren“, „buchstabiertafel“, „buchstabiertafel inland“, „zahlentafel“ |
-| `/funksprueche/` | 11 | „beispiel-funksprüche ansehen“, „fertige funksprüche“, „funkspruch-vorlagen“, „funksprüche“, „funksprüche ansehen“, „funksprüche für übungen“, „funksprüchen“, „vorlagen“, „über 1.800 funksprüche“, „über 1.800 funksprüchen“, „übungspool“ |
+| `/regiebuch-funkuebung/` | 11 | „auswertung“, „live-cockpit“, „live-nachrichtenplan“, „live-übungsleitung“, „live-übungsleitung ansehen“, „nachrichtenplan“, „nachrichtenplan ansehen“, „regiebuch“, „regiebuch der übung“, „regiebuch mit live-übungsleitung“, „übungsleitung“ |
+| `/funksprueche/` | 11 | „3.684 funksprüche“, „3.684 funksprüchen“, „beispiel-funksprüche ansehen“, „fertige funksprüche“, „funkspruch-vorlagen“, „funksprüche“, „funksprüche ansehen“, „funksprüche für übungen“, „funksprüchen“, „vorlagen“, „übungspool“ |
 | `/sprechfunk-regeln/` | 6 | „anrufverfahren“, „funkdisziplin“, „sprechfunk-regeln“, „sprechfunk-regeln im bos-funk“, „sprechfunkregeln“, „sprechfunkverkehr“ |
 | `/anleitung/` | 4 | „anleitung“, „schritt-für-schritt-anleitung“, „sprechfunkübung“, „zur anleitung“ |
 | `/funkuebung-planen/` | 8 | „funkübung“, „funkübung planen“, „geplanten funkübung“, „planen“, „planung einer funkübung“, „schritt-für-schritt-planung“, „übung“, „übungsplanung“ |
@@ -69,20 +75,26 @@ Keine. Jede Inhaltsseite hat mindestens einen eingehenden Fließtext-Link.
 | `/open-source/` | 2 | „kostenlos, ohne anmeldung, quelloffen“, „kostenlos, quelloffen (eupl-1.2) und datensparsam“ |
 | `/funkuebung-dienstabend/` | 4 | „ablauf für den dienstabend“, „dienstabend“, „funkübung am dienstabend“, „funkübung für den dienstabend“ |
 | `/digitale-funkuebung/` | 5 | „digital am smartphone“, „digitale funkübung“, „digitale funkübung per smartphone“, „digitalen funkübung“, „teilnehmeransicht“ |
+| `/funkrufnamen/` | 4 | „funkrufnamen“, „funkrufnamen im bos-funk“, „funkrufnamen verstehen“, „funkrufnamens“ |
 | `/funkuebung-thw/` | 4 | „funkübung im thw“, „funkübung thw“, „thw“, „thw-ortsverbände“ |
 | `/betriebsworte/` | 4 | „betriebsworte“, „betriebsworte im bos-funk“, „kommen“, „„ich buchstabiere““ |
-| `/funkrufnamen/` | 4 | „funkrufnamen“, „funkrufnamen im bos-funk“, „funkrufnamen verstehen“, „funkrufnamens“ |
 | `/funkuebung-feuerwehr/` | 2 | „feuerwehr“, „funkübung feuerwehr“ |
 | `/funkuebung-vorlage/` | 4 | „fertige vorlagen“, „fertige vorlagen ansehen“, „funkübungen als pdf“, „übungs-vorlagen“ |
-| `/funkuebung-szenarien/` | 5 | „12 szenarien für die funkübung“, „eingekleideten szenario-übung“, „szenario“, „szenario-ideen“, „übungsszenario“ |
+| `/funkuebung-szenarien/` | 6 | „12 szenarien für die funkübung“, „eingekleideten szenario-übung“, „szenarien für die funkübung“, „szenario“, „szenario-ideen“, „übungsszenario“ |
 | `/uebungsfunkverkehr/` | 2 | „blitz- und staatsnot-nachrichten“, „übungsfunkverkehr“ |
 | `/funkreichweite/` | 3 | „merkregeln zur störungsbeseitigung“, „reichweite“, „reichweite von funkwellen“ |
+| `/x-zeit/` | 4 | „der x-zeit-modus“, „fälligkeitszeitpunkt als x+n“, „x-zeit“, „zeitversetzte fälligkeiten“ |
+| `/funksprueche/vorlage/thw-lehrte/` | 4 | „752 nachrichten aus lehrte“, „große unwetterlage aus lehrte“, „thw lehrte“, „unwetterlage aus lehrte“ |
+| `/funksprueche/vorlage/thw-melle/` | 4 | „400 nachrichten aus melle“, „fachdichte lage aus melle“, „thw melle“, „vorlage aus melle“ |
+| `/funkuebung-katastrophenschutz/` | 4 | „funkübung im katastrophenschutz“, „hilfsorganisationen“, „katastrophenschutz“, „mehrere organisationen“ |
 | `/verkehrsarten/` | 2 | „verkehrsarten“, „verkehrsarten und relaisbetrieb“ |
 | `/antennen/` | 3 | „antennen“, „antennen und antennenleitungen“, „art der antenne“ |
-| `/x-zeit/` | 4 | „der x-zeit-modus“, „fälligkeitszeitpunkt als x+n“, „x-zeit“, „zeitversetzte fälligkeiten“ |
 | `/faq/` | 2 | „faq“, „häufige fragen“ |
 | `/funktionen/` | 3 | „alle funktionen im überblick“, „bausteinen der anwendung“, „überblick über die funktionen“ |
-| `/funkuebung-katastrophenschutz/` | 3 | „funkübung im katastrophenschutz“, „hilfsorganisationen“, „katastrophenschutz“ |
+| `/funksprueche/vorlage/grundausbildung-einfach/` | 3 | „grundausbildung, einfache nachrichten“, „sammlung kurzer meldungen aus der grundausbildung“, „vorlage für die grundausbildung“ |
+| `/funksprueche/vorlage/thw-essen/` | 3 | „92 nachrichten aus essen“, „hochwasserlage aus essen“, „thw essen“ |
+| `/funksprueche/vorlage/thw-leer/` | 3 | „118 nachrichten aus leer“, „sturmlage aus ostfriesland“, „thw leer“ |
+| `/funksprueche/vorlage/thw-saarstedt/` | 3 | „200 standortmeldungen aus saarstedt“, „200 standortmeldungen mit straßennamen in großbuchstaben“, „thw saarstedt“ |
 | `/funkrufnamen-thw/` | 1 | „funkrufnamen im thw“ |
 | `/funkmeldesystem/` | 3 | „funkmeldesystem“, „statusmeldungen“, „statusmeldungen nach dem funkmeldesystem“ |
 | `/wissen/` | 3 | „alle themen im sprechfunk-wissen“, „sprechfunk-wissen“, „übersicht sprechfunk-wissen“ |

--- a/src/index.html
+++ b/src/index.html
@@ -17,11 +17,11 @@
     <link rel="preload" href="webfonts/fa-brands-400.woff2" as="font" type="font/woff2" crossorigin>
     <script type="module" src="bundle.js"></script>
 
-    <meta name="description" content="BOS-Sprechfunkübung für Feuerwehr, THW und Katastrophenschutz online erstellen – kostenlos, ohne Anmeldung, ohne Installation. Mit über 1.800 fertigen Funksprüchen, PDF-Vordrucken und Live-Übungsleitung.">
+    <meta name="description" content="BOS-Sprechfunkübung für Feuerwehr, THW und Katastrophenschutz online erstellen – kostenlos, ohne Anmeldung, ohne Installation. Mit 3.684 fertigen Funksprüchen, PDF-Vordrucken und Live-Übungsleitung.">
     <meta name="author" content="Johannes Rudolph">
 
     <meta property="og:title" content="BOS Sprechfunk Übung erstellen für Feuerwehr & THW – kostenlos, ohne Anmeldung">
-    <meta property="og:description" content="BOS-Sprechfunkübung für Feuerwehr, THW und Katastrophenschutz online erstellen – kostenlos, ohne Anmeldung, ohne Installation. Mit über 1.800 fertigen Funksprüchen, PDF-Vordrucken und Live-Übungsleitung.">
+    <meta property="og:description" content="BOS-Sprechfunkübung für Feuerwehr, THW und Katastrophenschutz online erstellen – kostenlos, ohne Anmeldung, ohne Installation. Mit 3.684 fertigen Funksprüchen, PDF-Vordrucken und Live-Übungsleitung.">
     <meta property="og:url" content="https://sprechfunk-uebung.de/">
     <meta property="og:type" content="website">
     <meta property="og:locale" content="de_DE">
@@ -196,7 +196,7 @@
                     <strong>Rettungsdienst</strong> und Katastrophenschutz – im Browser,
                     ohne Installation und ohne Benutzerkonto: Teilnehmer mit Funkrufnamen
                     eintragen, Anzahl der Funksprüche festlegen, fertig. Die Anwendung
-                    verteilt über 1.800
+                    verteilt {{FUNKSPRUECHE_GESAMT}}
                     <a href="funksprueche/">Funksprüche</a> automatisch, erzeugt
                     <a href="meldevordruck/">Meldevordruck und Nachrichtenvordruck</a> als PDF
                     und begleitet die Übung live – alle Details zeigt der

--- a/src/pages/betriebsworte.html
+++ b/src/pages/betriebsworte.html
@@ -302,7 +302,7 @@
                     Eine Tabelle kann man abfragen – sicher anwenden lassen sich Betriebsworte
                     erst, wenn sie unter leichtem Zeitdruck aus dem Kopf kommen. Der
                     <strong>Sprechfunk Übungsgenerator</strong> baut dafür die Situationen:
-                    Er verteilt <a href="../funksprueche/">über 1.800 Funksprüche</a> auf die
+                    Er verteilt <a href="../funksprueche/">{{FUNKSPRUECHE_GESAMT}} Funksprüche</a> auf die
                     Teilnehmer, erzeugt <a href="../meldevordruck/">Meldevordrucke</a> zum
                     Mitschreiben und liefert der Übungsleitung ein
                     <a href="../regiebuch-funkuebung/">Regiebuch</a> für die Auswertung.

--- a/src/pages/bos-funk.html
+++ b/src/pages/bos-funk.html
@@ -312,7 +312,7 @@
                     Rufgruppe schalten kann jeder nach fünf Minuten Einweisung – sicheres,
                     diszipliniertes Funken kommt nur durch Übung. Der Sprechfunk
                     Übungsgenerator erstellt dafür komplette Übungen mit
-                    <a href="../funksprueche/">über 1.800 Funksprüchen</a>,
+                    <a href="../funksprueche/">{{FUNKSPRUECHE_GESAMT}} Funksprüchen</a>,
                     PDF-Vordrucken und <a href="../regiebuch-funkuebung/">Live-Übungsleitung</a> –
                     passende Übungsideen liefern die
                     <a href="../funkuebung-szenarien/">12 Szenarien für die Funkübung</a>.

--- a/src/pages/buchstabiertafel.html
+++ b/src/pages/buchstabiertafel.html
@@ -346,6 +346,15 @@
         </div>
 
         <div class="card mb-3">
+        <section class="card shadow-sm mb-4">
+            <div class="card-header"><h2 class="h4 mb-0" id="buchstabieren-ueben">Buchstabieren über eine ganze Übung üben</h2></div>
+            <div class="card-body">
+                <p>Die Tafel sitzt erst, wenn sie im Betrieb funktioniert. Dafür braucht es Wiederholung an unhandlichen Namen, nicht an drei Beispielwörtern.</p>
+                <p>Im Archiv liegt dafür eine eigene Vorlage: <a href="../funksprueche/vorlage/thw-saarstedt/">200 Standortmeldungen mit Straßennamen in Großbuchstaben</a>. LÖNSSTRASSE verlangt Umlaut und Doppelkonsonanten, GIEBELSTIEG einen Wortteil, den man selten hört.</p>
+                <p class="mb-0">Zusätzlich lassen sich im Generator Lösungswörter einschalten. Dann kommt zu den Ortsnamen ein Wort, das über die Übung hinweg buchstabiert und am Ende abgefragt wird.</p>
+            </div>
+        </section>
+
             <div class="card-header"><h2 class="h4 mb-0" id="regeln">Richtig buchstabieren im Funkverkehr</h2></div>
             <div class="card-body">
                 <ul>

--- a/src/pages/funksprueche-vorlage-grundausbildung-einfach.html
+++ b/src/pages/funksprueche-vorlage-grundausbildung-einfach.html
@@ -1,0 +1,177 @@
+<!DOCTYPE html>
+<html lang="de">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Einfache Funksprüche für die Sprechfunk-Grundausbildung</title>
+    <link rel="icon" type="image/png" href="../../../assets/favicon.png">
+    <link rel="canonical" href="https://sprechfunk-uebung.de/funksprueche/vorlage/grundausbildung-einfach/">
+    <meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1">
+    <meta name="theme-color" content="#0d6efd">
+
+    <meta name="description" content="462 kurze Übungsnachrichten für die erste Funkübung nach dem Lehrgang: Anruf, Anrufantwort und Standortmeldung ohne langen Text zum Mitschreiben.">
+    <meta name="author" content="Johannes Rudolph">
+
+    <meta property="og:title" content="Einfache Funksprüche für die Sprechfunk-Grundausbildung">
+    <meta property="og:description" content="462 kurze Übungsnachrichten für die erste Funkübung nach dem Lehrgang: Anruf, Anrufantwort und Standortmeldung ohne langen Text zum Mitschreiben.">
+    <meta property="og:url" content="https://sprechfunk-uebung.de/funksprueche/vorlage/grundausbildung-einfach/">
+    <meta property="og:type" content="article">
+    <meta property="og:locale" content="de_DE">
+    <meta property="og:site_name" content="Sprechfunk Übungsgenerator">
+    <meta property="og:image" content="https://sprechfunk-uebung.de/assets/og-image.png">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">
+    <meta property="og:image:alt" content="Sprechfunk Übungsgenerator – Übungen für den BOS-Sprechfunk erstellen">
+
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Einfache Funksprüche für die Sprechfunk-Grundausbildung">
+    <meta name="twitter:description" content="462 kurze Übungsnachrichten für die erste Funkübung nach dem Lehrgang: Anruf, Anrufantwort und Standortmeldung ohne langen Text zum Mitschreiben.">
+    <meta name="twitter:image" content="https://sprechfunk-uebung.de/assets/og-image.png">
+
+    <link rel="stylesheet" href="../../../bundle.css">
+    <link rel="stylesheet" href="../../../style.css">
+
+    <!-- GoatCounter: cookielose, anonyme Reichweitenmessung -->
+    <script data-goatcounter="https://sprechfunk-uebung.goatcounter.com/count"
+            async src="//gc.zgo.at/count.js"></script>
+
+    <script>
+        // Gleiche Theme-Auswahl wie in der App anwenden (statische Seiten laden kein Bundle).
+        document.addEventListener("DOMContentLoaded", function () {
+            var stored = localStorage.getItem("theme");
+            if (stored) {
+                document.body.setAttribute("data-theme", stored);
+            }
+        });
+    </script>
+</head>
+
+<body data-theme="light">
+<header class="app-header">
+    <div class="container app-header-grid">
+        <div class="app-header-title">
+            <p class="h2 mb-0">
+                <i class="fas fa-broadcast-tower"></i> Sprechfunk Übungsgenerator
+            </p>
+        </div>
+        <div class="app-header-actions d-none d-md-flex">
+            <a href="../../../" class="btn btn-primary">
+                <i class="fas fa-arrow-left"></i> Zur Anwendung
+            </a>
+            <a href="../../../anleitung/" class="btn btn-info">
+                <i class="fas fa-book"></i> Anleitung
+            </a>
+            <a href="https://github.com/wattnpapa/sprechfunk-uebung" class="btn btn-dark">
+                <i class="fab fa-github"></i> GitHub
+            </a>
+        </div>
+    </div>
+</header>
+
+<main class="container my-4 app-view-shell">
+    <nav aria-label="Brotkrumennavigation" class="mb-3">
+        <ol class="breadcrumb mb-0">
+            <li class="breadcrumb-item"><a href="../../../">Startseite</a></li>
+            <li class="breadcrumb-item"><a href="../../../funksprueche/">Funksprüche</a></li>
+            <li class="breadcrumb-item active" aria-current="page">Vorlage Grundausbildung</li>
+        </ol>
+    </nav>
+
+    <article>
+        <div class="card mb-3">
+            <div class="card-body">
+                <h1 class="h3">Einfache Funksprüche für die Grundausbildung</h1>
+                <p class="mb-0">
+                    Diese Vorlage enthält <strong>462 kurze Übungsnachrichten</strong> für den
+                    Einstieg. Sie sind bewusst knapp gehalten: die Hälfte liegt unter 50
+                    Zeichen. Damit steht nicht der Nachrichtentext im Mittelpunkt, sondern das
+                    Verfahren.
+                </p>
+            </div>
+        </div>
+
+        <section class="card shadow-sm mb-4">
+            <div class="card-header"><h2 class="h4 mb-0" id="wofuer">Wofür diese Vorlage gedacht ist</h2></div>
+            <div class="card-body">
+                <p>In der ersten Übung nach dem Lehrgang scheitert selten der Inhalt. Es scheitert das Verfahren: wer ruft wen, wann wird gesprochen, wann bestätigt.</p>
+                <p>Lange Nachrichten verdecken das. Wer 200 Zeichen mitschreibt, ist mit dem Stift beschäftigt und nicht mit dem Ablauf. Kurze Texte machen viele Durchgänge in kurzer Zeit möglich.</p>
+                <p class="mb-0">Genau dafür ist die Vorlage gebaut. Bei 30 Sekunden je Verkehr schafft eine Funkstelle in einer Viertelstunde ein Dutzend Anrufe. Das ist die Wiederholungszahl, aus der Routine entsteht.</p>
+            </div>
+        </section>
+
+        <section class="card shadow-sm mb-4">
+            <div class="card-header"><h2 class="h4 mb-0" id="nachrichteninhalt">Was in den Nachrichten steht</h2></div>
+            <div class="card-body">
+                <p>Der Bestand deckt die wiederkehrenden Meldungen eines Einsatzes ab: Abrücken, Ankommen, Standort, Einsatzbereitschaft, Rückfragen. Beispiele im Wortlaut: <em>„Sind einsatzbereit.“</em>, <em>„Haben den Treffpunkt erreicht.“</em>, <em>„Frage: Wie ist Ihr Standort?“</em>.</p>
+                <p>Diese Sätze sind keine Erfindung für die Übung. Sie sind das, was im Einsatz tatsächlich über den Kanal geht, und deshalb der richtige Stoff für den Anfang.</p>
+                <p class="mb-0">Ein Teil der Einträge enthält ein Wort in Großbuchstaben, meist einen Orts- oder Straßennamen. Diese Nachrichten eignen sich für erste Übungen nach der <a href="../../../buchstabiertafel/">Buchstabiertafel</a>.</p>
+            </div>
+        </section>
+
+        <section class="card shadow-sm mb-4">
+            <div class="card-header"><h2 class="h4 mb-0" id="einsetzen">So setzt du die Vorlage ein</h2></div>
+            <div class="card-body">
+                <p>Für einen ersten Abend haben sich sechs bis acht Funkstellen mit je sechs Nachrichten bewährt. Das sind rund 45 Verkehre auf dem Kanal und passt in eine Stunde Übungsbetrieb.</p>
+                <p>Den Buchstabieranteil setzt du im Generator zunächst auf null. Nach zwei oder drei Abenden lässt er sich schrittweise anheben, ohne die Vorlage zu wechseln.</p>
+                <p class="mb-0">Wer den nächsten Schritt gehen will, wechselt auf eine der THW-Vorlagen. Deren Nachrichten sind mehrfach länger und verlangen eine geordnete Mitschrift im <a href="../../../meldevordruck/">Meldevordruck</a>.</p>
+            </div>
+        </section>
+
+        <section class="card shadow-sm mb-4">
+            <div class="card-header"><h2 class="h4 mb-0" id="download">Herunterladen und im Generator nutzen</h2></div>
+            <div class="card-body">
+                <p>
+                    Die Datei enthält eine Nachricht je Zeile – genau das Format, das der
+                    Generator beim Upload liest. Herunterladen, im Generator
+                    <em>Eigene Datei hochladen</em> wählen, fertig.
+                </p>
+                <p>
+                    <a class="btn btn-primary" href="../../../assets/funksprueche-grundausbildung-einfach.txt"
+                       download data-testid="download-txt">Alle 462 Funksprüche als Textdatei</a>
+                    <a class="btn btn-outline-primary" href="../../../">Übung erstellen</a>
+                </p>
+                <p class="mb-0">
+                    Die Nutzung steht unter der
+                    <a href="https://github.com/wattnpapa/sprechfunk-uebung/blob/main/LICENSE" target="_blank" rel="noopener noreferrer">EUPL-1.2</a>.
+                    Eigene Übungstexte nimmt das Projekt gern auf: an
+                    <a href="mailto:johannes.rudolph@thw-oldenburg.de">johannes.rudolph@thw-oldenburg.de</a>
+                    senden, eine Nachricht je Zeile.
+                </p>
+            </div>
+        </section>
+
+        <section class="card shadow-sm mb-4">
+            <div class="card-header"><h2 class="h4 mb-0" id="alle-funksprueche">Alle 462 Funksprüche dieser Vorlage</h2></div>
+            <div class="card-body">
+                <p>
+                    Der vollständige Bestand dieser Vorlage. Suche und Filter arbeiten im
+                    Browser; ohne JavaScript bleibt die Liste vollständig sichtbar.
+                </p>
+<!-- AP-08:LISTE -->
+            </div>
+        </section>
+    </article>
+</main>
+
+<footer class="main-footer">
+    <span class="footer-links">
+        <a href="../../../">Anwendung</a>
+        <a href="../../../anleitung/">Anleitung</a>
+        <a href="../../../buchstabiertafel/">Buchstabiertafel</a>
+        <a href="../../../meldevordruck/">Meldevordruck</a>
+        <a href="../../../funksprueche/">Funksprüche</a>
+        <a href="../../../faq/">FAQ</a>
+    </span>
+    <span class="footer-links">
+        <a href="../../../impressum/">Impressum</a>
+        <a href="../../../datenschutz/">Datenschutz</a>
+        <a href="mailto:johannes.rudolph@thw-oldenburg.de">Kontakt</a>
+        <a href="https://github.com/wattnpapa/sprechfunk-uebung" target="_blank" rel="noopener noreferrer">GitHub</a>
+        <a href="https://github.com/wattnpapa/sprechfunk-uebung/blob/main/LICENSE" target="_blank" rel="noopener noreferrer">EUPL-1.2-Lizenz</a>
+    </span>
+</footer>
+
+</body>
+
+</html>

--- a/src/pages/funksprueche-vorlage-thw-essen.html
+++ b/src/pages/funksprueche-vorlage-thw-essen.html
@@ -1,0 +1,177 @@
+<!DOCTYPE html>
+<html lang="de">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Funksprüche THW Essen: Deichbruch an der Emscher üben</title>
+    <link rel="icon" type="image/png" href="../../../assets/favicon.png">
+    <link rel="canonical" href="https://sprechfunk-uebung.de/funksprueche/vorlage/thw-essen/">
+    <meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1">
+    <meta name="theme-color" content="#0d6efd">
+
+    <meta name="description" content="92 Übungsnachrichten aus einer Hochwasserlage im Essener Stadtgebiet: Erkundungsaufträge, Stärkemeldungen, Lotsenanforderung und Koordinaten im UTM-Format.">
+    <meta name="author" content="Johannes Rudolph">
+
+    <meta property="og:title" content="Funksprüche THW Essen: Deichbruch an der Emscher üben">
+    <meta property="og:description" content="92 Übungsnachrichten aus einer Hochwasserlage im Essener Stadtgebiet: Erkundungsaufträge, Stärkemeldungen, Lotsenanforderung und Koordinaten im UTM-Format.">
+    <meta property="og:url" content="https://sprechfunk-uebung.de/funksprueche/vorlage/thw-essen/">
+    <meta property="og:type" content="article">
+    <meta property="og:locale" content="de_DE">
+    <meta property="og:site_name" content="Sprechfunk Übungsgenerator">
+    <meta property="og:image" content="https://sprechfunk-uebung.de/assets/og-image.png">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">
+    <meta property="og:image:alt" content="Sprechfunk Übungsgenerator – Übungen für den BOS-Sprechfunk erstellen">
+
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Funksprüche THW Essen: Deichbruch an der Emscher üben">
+    <meta name="twitter:description" content="92 Übungsnachrichten aus einer Hochwasserlage im Essener Stadtgebiet: Erkundungsaufträge, Stärkemeldungen, Lotsenanforderung und Koordinaten im UTM-Format.">
+    <meta name="twitter:image" content="https://sprechfunk-uebung.de/assets/og-image.png">
+
+    <link rel="stylesheet" href="../../../bundle.css">
+    <link rel="stylesheet" href="../../../style.css">
+
+    <!-- GoatCounter: cookielose, anonyme Reichweitenmessung -->
+    <script data-goatcounter="https://sprechfunk-uebung.goatcounter.com/count"
+            async src="//gc.zgo.at/count.js"></script>
+
+    <script>
+        // Gleiche Theme-Auswahl wie in der App anwenden (statische Seiten laden kein Bundle).
+        document.addEventListener("DOMContentLoaded", function () {
+            var stored = localStorage.getItem("theme");
+            if (stored) {
+                document.body.setAttribute("data-theme", stored);
+            }
+        });
+    </script>
+</head>
+
+<body data-theme="light">
+<header class="app-header">
+    <div class="container app-header-grid">
+        <div class="app-header-title">
+            <p class="h2 mb-0">
+                <i class="fas fa-broadcast-tower"></i> Sprechfunk Übungsgenerator
+            </p>
+        </div>
+        <div class="app-header-actions d-none d-md-flex">
+            <a href="../../../" class="btn btn-primary">
+                <i class="fas fa-arrow-left"></i> Zur Anwendung
+            </a>
+            <a href="../../../anleitung/" class="btn btn-info">
+                <i class="fas fa-book"></i> Anleitung
+            </a>
+            <a href="https://github.com/wattnpapa/sprechfunk-uebung" class="btn btn-dark">
+                <i class="fab fa-github"></i> GitHub
+            </a>
+        </div>
+    </div>
+</header>
+
+<main class="container my-4 app-view-shell">
+    <nav aria-label="Brotkrumennavigation" class="mb-3">
+        <ol class="breadcrumb mb-0">
+            <li class="breadcrumb-item"><a href="../../../">Startseite</a></li>
+            <li class="breadcrumb-item"><a href="../../../funksprueche/">Funksprüche</a></li>
+            <li class="breadcrumb-item active" aria-current="page">Vorlage THW Essen</li>
+        </ol>
+    </nav>
+
+    <article>
+        <div class="card mb-3">
+            <div class="card-body">
+                <h1 class="h3">Funksprüche THW Essen: Hochwasser an der Emscher</h1>
+                <p class="mb-0">
+                    Diese Vorlage enthält <strong>92 Übungsnachrichten</strong> aus einer
+                    Hochwasserlage im Essener Stadtgebiet. Ausgangspunkt ist ein Deichbruch an
+                    der Emscher; von dort verzweigt sich die Lage in Erkundungsaufträge,
+                    Anforderungen und Rückmeldungen.
+                </p>
+            </div>
+        </div>
+
+        <section class="card shadow-sm mb-4">
+            <div class="card-header"><h2 class="h4 mb-0" id="lage">Die Lage hinter den Nachrichten</h2></div>
+            <div class="card-body">
+                <p>Ein Deichbruch an der Emscher setzt Teile des Stadtgebiets unter Wasser. Die Nachrichten folgen dem, was in so einer Lage anfällt: erkunden, melden, anfordern, nachsteuern.</p>
+                <p>Eine Nachricht im Wortlaut: <em>„Im Bereich Emscherstr. Ecke Karnaper Str. vermuten wir eine Überschwemmung nach Deichbruch an der Emscher. Erkunden Sie das Gebiet.“</em> Daran hängen Folgemeldungen, die das Ergebnis zurückgeben.</p>
+                <p class="mb-0">Die Ortsangaben sind echte Straßen im Essener Norden. Für eine Übung außerhalb von Essen ist das kein Hindernis – die Namen sind Buchstabierstoff, ob man sie kennt oder nicht.</p>
+            </div>
+        </section>
+
+        <section class="card shadow-sm mb-4">
+            <div class="card-header"><h2 class="h4 mb-0" id="besonderheit">Was diese Vorlage besonders übt</h2></div>
+            <div class="card-body">
+                <p>Zwei Dinge kommen hier häufiger vor als in den übrigen Vorlagen. Erstens die <strong>Stärkemeldung</strong> in ihrer üblichen Schreibweise, etwa <em>„Verlassen mit der Stärke 0/1/1//2 die Unterkunft. Frage: Sonderrechte?“</em>.</p>
+                <p>Zweitens die <strong>Koordinatenangabe</strong>. Eine Nachricht erbittet Lotsen an Punkt <em>32 U LC 562 087</em>. Wer das fehlerfrei übermittelt und zurückliest, hat den Kern der Verkehrsdisziplin verstanden.</p>
+                <p class="mb-0">Beides ist im Einsatz alltäglich und wird in Übungen oft übersprungen, weil frei erfundene Lagen ohne Zahlen auskommen. Hier kommen sie vor.</p>
+            </div>
+        </section>
+
+        <section class="card shadow-sm mb-4">
+            <div class="card-header"><h2 class="h4 mb-0" id="umfang">Umfang und Zuschnitt</h2></div>
+            <div class="card-body">
+                <p>92 Nachrichten reichen für einen Übungsabend mit acht Funkstellen und je zehn Sprüchen. Die Hälfte der Texte liegt bei etwa 130 Zeichen, was rund eine Minute Mitschrift bedeutet.</p>
+                <p>Für eine kürzere Übung setzt du die Zahl der Sprüche je Teilnehmer herunter; der Generator wählt dann aus dem Bestand aus. Für eine längere lassen sich zwei Vorlagen gleichzeitig auswählen.</p>
+                <p class="mb-0">Wie sich der Umfang auf die Dauer auswirkt, rechnet die Statistik-Ansicht vor. Einen Zeitplan bekommt die Übung über die <a href="../../../x-zeit/">X-Zeit</a>.</p>
+            </div>
+        </section>
+
+        <section class="card shadow-sm mb-4">
+            <div class="card-header"><h2 class="h4 mb-0" id="download">Herunterladen und im Generator nutzen</h2></div>
+            <div class="card-body">
+                <p>
+                    Die Datei enthält eine Nachricht je Zeile – genau das Format, das der
+                    Generator beim Upload liest. Herunterladen, im Generator
+                    <em>Eigene Datei hochladen</em> wählen, fertig.
+                </p>
+                <p>
+                    <a class="btn btn-primary" href="../../../assets/funksprueche-thw-essen.txt"
+                       download data-testid="download-txt">Alle 92 Funksprüche als Textdatei</a>
+                    <a class="btn btn-outline-primary" href="../../../">Übung erstellen</a>
+                </p>
+                <p class="mb-0">
+                    Die Nutzung steht unter der
+                    <a href="https://github.com/wattnpapa/sprechfunk-uebung/blob/main/LICENSE" target="_blank" rel="noopener noreferrer">EUPL-1.2</a>.
+                    Eigene Übungstexte nimmt das Projekt gern auf: an
+                    <a href="mailto:johannes.rudolph@thw-oldenburg.de">johannes.rudolph@thw-oldenburg.de</a>
+                    senden, eine Nachricht je Zeile.
+                </p>
+            </div>
+        </section>
+
+        <section class="card shadow-sm mb-4">
+            <div class="card-header"><h2 class="h4 mb-0" id="alle-funksprueche">Alle 92 Funksprüche dieser Vorlage</h2></div>
+            <div class="card-body">
+                <p>
+                    Der vollständige Bestand dieser Vorlage. Suche und Filter arbeiten im
+                    Browser; ohne JavaScript bleibt die Liste vollständig sichtbar.
+                </p>
+<!-- AP-08:LISTE -->
+            </div>
+        </section>
+    </article>
+</main>
+
+<footer class="main-footer">
+    <span class="footer-links">
+        <a href="../../../">Anwendung</a>
+        <a href="../../../anleitung/">Anleitung</a>
+        <a href="../../../buchstabiertafel/">Buchstabiertafel</a>
+        <a href="../../../meldevordruck/">Meldevordruck</a>
+        <a href="../../../funksprueche/">Funksprüche</a>
+        <a href="../../../faq/">FAQ</a>
+    </span>
+    <span class="footer-links">
+        <a href="../../../impressum/">Impressum</a>
+        <a href="../../../datenschutz/">Datenschutz</a>
+        <a href="mailto:johannes.rudolph@thw-oldenburg.de">Kontakt</a>
+        <a href="https://github.com/wattnpapa/sprechfunk-uebung" target="_blank" rel="noopener noreferrer">GitHub</a>
+        <a href="https://github.com/wattnpapa/sprechfunk-uebung/blob/main/LICENSE" target="_blank" rel="noopener noreferrer">EUPL-1.2-Lizenz</a>
+    </span>
+</footer>
+
+</body>
+
+</html>

--- a/src/pages/funksprueche-vorlage-thw-leer.html
+++ b/src/pages/funksprueche-vorlage-thw-leer.html
@@ -1,0 +1,176 @@
+<!DOCTYPE html>
+<html lang="de">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Funksprüche THW Leer: Sturmschäden in Ostfriesland üben</title>
+    <link rel="icon" type="image/png" href="../../../assets/favicon.png">
+    <link rel="canonical" href="https://sprechfunk-uebung.de/funksprueche/vorlage/thw-leer/">
+    <meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1">
+    <meta name="theme-color" content="#0d6efd">
+
+    <meta name="description" content="118 Übungsnachrichten aus einer Sturm- und Hochwasserlage in Ostfriesland: versperrte Landesstraßen, volle Keller, Bergungsaufträge und drohende Uferüberläufe.">
+    <meta name="author" content="Johannes Rudolph">
+
+    <meta property="og:title" content="Funksprüche THW Leer: Sturmschäden in Ostfriesland üben">
+    <meta property="og:description" content="118 Übungsnachrichten aus einer Sturm- und Hochwasserlage in Ostfriesland: versperrte Landesstraßen, volle Keller, Bergungsaufträge und drohende Uferüberläufe.">
+    <meta property="og:url" content="https://sprechfunk-uebung.de/funksprueche/vorlage/thw-leer/">
+    <meta property="og:type" content="article">
+    <meta property="og:locale" content="de_DE">
+    <meta property="og:site_name" content="Sprechfunk Übungsgenerator">
+    <meta property="og:image" content="https://sprechfunk-uebung.de/assets/og-image.png">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">
+    <meta property="og:image:alt" content="Sprechfunk Übungsgenerator – Übungen für den BOS-Sprechfunk erstellen">
+
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Funksprüche THW Leer: Sturmschäden in Ostfriesland üben">
+    <meta name="twitter:description" content="118 Übungsnachrichten aus einer Sturm- und Hochwasserlage in Ostfriesland: versperrte Landesstraßen, volle Keller, Bergungsaufträge und drohende Uferüberläufe.">
+    <meta name="twitter:image" content="https://sprechfunk-uebung.de/assets/og-image.png">
+
+    <link rel="stylesheet" href="../../../bundle.css">
+    <link rel="stylesheet" href="../../../style.css">
+
+    <!-- GoatCounter: cookielose, anonyme Reichweitenmessung -->
+    <script data-goatcounter="https://sprechfunk-uebung.goatcounter.com/count"
+            async src="//gc.zgo.at/count.js"></script>
+
+    <script>
+        // Gleiche Theme-Auswahl wie in der App anwenden (statische Seiten laden kein Bundle).
+        document.addEventListener("DOMContentLoaded", function () {
+            var stored = localStorage.getItem("theme");
+            if (stored) {
+                document.body.setAttribute("data-theme", stored);
+            }
+        });
+    </script>
+</head>
+
+<body data-theme="light">
+<header class="app-header">
+    <div class="container app-header-grid">
+        <div class="app-header-title">
+            <p class="h2 mb-0">
+                <i class="fas fa-broadcast-tower"></i> Sprechfunk Übungsgenerator
+            </p>
+        </div>
+        <div class="app-header-actions d-none d-md-flex">
+            <a href="../../../" class="btn btn-primary">
+                <i class="fas fa-arrow-left"></i> Zur Anwendung
+            </a>
+            <a href="../../../anleitung/" class="btn btn-info">
+                <i class="fas fa-book"></i> Anleitung
+            </a>
+            <a href="https://github.com/wattnpapa/sprechfunk-uebung" class="btn btn-dark">
+                <i class="fab fa-github"></i> GitHub
+            </a>
+        </div>
+    </div>
+</header>
+
+<main class="container my-4 app-view-shell">
+    <nav aria-label="Brotkrumennavigation" class="mb-3">
+        <ol class="breadcrumb mb-0">
+            <li class="breadcrumb-item"><a href="../../../">Startseite</a></li>
+            <li class="breadcrumb-item"><a href="../../../funksprueche/">Funksprüche</a></li>
+            <li class="breadcrumb-item active" aria-current="page">Vorlage THW Leer</li>
+        </ol>
+    </nav>
+
+    <article>
+        <div class="card mb-3">
+            <div class="card-body">
+                <h1 class="h3">Funksprüche THW Leer: Sturm und Hochwasser</h1>
+                <p class="mb-0">
+                    Diese Vorlage enthält <strong>118 Übungsnachrichten</strong> aus einer Sturm-
+                    und Hochwasserlage in Ostfriesland. Sie ist eine Flächenlage: viele kleine
+                    Einsatzstellen gleichzeitig, verteilt über ein großes Gebiet.
+                </p>
+            </div>
+        </div>
+
+        <section class="card shadow-sm mb-4">
+            <div class="card-header"><h2 class="h4 mb-0" id="flaechenlage">Eine Flächenlage, keine Einsatzstelle</h2></div>
+            <div class="card-body">
+                <p>Der Unterschied entscheidet über den Charakter der Übung. Bei einer Einsatzstelle laufen viele Meldungen von einem Ort. Bei einer Flächenlage kommen einzelne Meldungen von überall.</p>
+                <p>Diese Vorlage ist der zweite Fall. Ein Sturm hat Bäume auf Landesstraßen geworfen, Keller stehen unter Wasser, ein See droht über die Ufer zu treten. Nichts davon ist allein groß, zusammen ist es viel.</p>
+                <p class="mb-0">Für die Übungsleitung heißt das: der Kanal ist gleichmäßig belegt, und die Funkstellen müssen entscheiden, was zuerst gemeldet wird. Das ist eine andere Übung als eine Großschadenslage – mehr dazu unter <a href="../../../funkuebung-szenarien/">Szenarien für die Funkübung</a>.</p>
+            </div>
+        </section>
+
+        <section class="card shadow-sm mb-4">
+            <div class="card-header"><h2 class="h4 mb-0" id="beispiele">Nachrichten im Wortlaut</h2></div>
+            <div class="card-body">
+                <p><em>„Herab gestürzte Äste und Baumteile versperren die Oldenburger Straße (L24) zwischen Hesel und Schwerinsdorf.“</em> – eine Meldung, die eine Entscheidung verlangt, aber keine Rückfrage.</p>
+                <p><em>„Das Timmeler Meer droht, auf Höhe der L14 über die Ufer zu treten. Erkunden Sie die Lage vor Ort und leiten Sie entsprechende Maßnahmen ein.“</em> – hier hängt ein Auftrag dran.</p>
+                <p class="mb-0"><em>„Beim Hotel am Fischereihafen in Ditzum steht der Keller (etwa 145 m²) 25 cm unter Wasser“</em> – mit Zahlenangaben, die vollständig ankommen müssen.</p>
+            </div>
+        </section>
+
+        <section class="card shadow-sm mb-4">
+            <div class="card-header"><h2 class="h4 mb-0" id="einsatz">Einsatz in der Übung</h2></div>
+            <div class="card-body">
+                <p>118 Nachrichten tragen einen Abend mit zehn Funkstellen. Die Texte sind mittellang; die meisten lassen sich in einem Durchgang aufnehmen, ohne dass wiederholt werden muss.</p>
+                <p>Weil viele Meldungen eine Entscheidung nach sich ziehen, lohnt eine besetzte Führungsstelle. Sie beantwortet Rückfragen und vergibt Aufträge, statt nur mitzuschreiben.</p>
+                <p class="mb-0">Der Bestand lässt sich mit der Lehrte-Vorlage kombinieren, wenn die Lage über den Abend hinaus eskalieren soll. Beide sind Unwetterlagen und passen inhaltlich zusammen.</p>
+            </div>
+        </section>
+
+        <section class="card shadow-sm mb-4">
+            <div class="card-header"><h2 class="h4 mb-0" id="download">Herunterladen und im Generator nutzen</h2></div>
+            <div class="card-body">
+                <p>
+                    Die Datei enthält eine Nachricht je Zeile – genau das Format, das der
+                    Generator beim Upload liest. Herunterladen, im Generator
+                    <em>Eigene Datei hochladen</em> wählen, fertig.
+                </p>
+                <p>
+                    <a class="btn btn-primary" href="../../../assets/funksprueche-thw-leer.txt"
+                       download data-testid="download-txt">Alle 118 Funksprüche als Textdatei</a>
+                    <a class="btn btn-outline-primary" href="../../../">Übung erstellen</a>
+                </p>
+                <p class="mb-0">
+                    Die Nutzung steht unter der
+                    <a href="https://github.com/wattnpapa/sprechfunk-uebung/blob/main/LICENSE" target="_blank" rel="noopener noreferrer">EUPL-1.2</a>.
+                    Eigene Übungstexte nimmt das Projekt gern auf: an
+                    <a href="mailto:johannes.rudolph@thw-oldenburg.de">johannes.rudolph@thw-oldenburg.de</a>
+                    senden, eine Nachricht je Zeile.
+                </p>
+            </div>
+        </section>
+
+        <section class="card shadow-sm mb-4">
+            <div class="card-header"><h2 class="h4 mb-0" id="alle-funksprueche">Alle 118 Funksprüche dieser Vorlage</h2></div>
+            <div class="card-body">
+                <p>
+                    Der vollständige Bestand dieser Vorlage. Suche und Filter arbeiten im
+                    Browser; ohne JavaScript bleibt die Liste vollständig sichtbar.
+                </p>
+<!-- AP-08:LISTE -->
+            </div>
+        </section>
+    </article>
+</main>
+
+<footer class="main-footer">
+    <span class="footer-links">
+        <a href="../../../">Anwendung</a>
+        <a href="../../../anleitung/">Anleitung</a>
+        <a href="../../../buchstabiertafel/">Buchstabiertafel</a>
+        <a href="../../../meldevordruck/">Meldevordruck</a>
+        <a href="../../../funksprueche/">Funksprüche</a>
+        <a href="../../../faq/">FAQ</a>
+    </span>
+    <span class="footer-links">
+        <a href="../../../impressum/">Impressum</a>
+        <a href="../../../datenschutz/">Datenschutz</a>
+        <a href="mailto:johannes.rudolph@thw-oldenburg.de">Kontakt</a>
+        <a href="https://github.com/wattnpapa/sprechfunk-uebung" target="_blank" rel="noopener noreferrer">GitHub</a>
+        <a href="https://github.com/wattnpapa/sprechfunk-uebung/blob/main/LICENSE" target="_blank" rel="noopener noreferrer">EUPL-1.2-Lizenz</a>
+    </span>
+</footer>
+
+</body>
+
+</html>

--- a/src/pages/funksprueche-vorlage-thw-lehrte.html
+++ b/src/pages/funksprueche-vorlage-thw-lehrte.html
@@ -1,0 +1,177 @@
+<!DOCTYPE html>
+<html lang="de">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Funksprüche THW Lehrte: Hochwasser und Bahnschäden üben</title>
+    <link rel="icon" type="image/png" href="../../../assets/favicon.png">
+    <link rel="canonical" href="https://sprechfunk-uebung.de/funksprueche/vorlage/thw-lehrte/">
+    <meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1">
+    <meta name="theme-color" content="#0d6efd">
+
+    <meta name="description" content="752 Übungsnachrichten aus einer großen Unwetterlage im Raum Lehrte und Burgdorf: überflutete Straßenzüge, beschädigte Bahnanlagen, ausgefallene Versorgung.">
+    <meta name="author" content="Johannes Rudolph">
+
+    <meta property="og:title" content="Funksprüche THW Lehrte: Hochwasser und Bahnschäden üben">
+    <meta property="og:description" content="752 Übungsnachrichten aus einer großen Unwetterlage im Raum Lehrte und Burgdorf: überflutete Straßenzüge, beschädigte Bahnanlagen, ausgefallene Versorgung.">
+    <meta property="og:url" content="https://sprechfunk-uebung.de/funksprueche/vorlage/thw-lehrte/">
+    <meta property="og:type" content="article">
+    <meta property="og:locale" content="de_DE">
+    <meta property="og:site_name" content="Sprechfunk Übungsgenerator">
+    <meta property="og:image" content="https://sprechfunk-uebung.de/assets/og-image.png">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">
+    <meta property="og:image:alt" content="Sprechfunk Übungsgenerator – Übungen für den BOS-Sprechfunk erstellen">
+
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Funksprüche THW Lehrte: Hochwasser und Bahnschäden üben">
+    <meta name="twitter:description" content="752 Übungsnachrichten aus einer großen Unwetterlage im Raum Lehrte und Burgdorf: überflutete Straßenzüge, beschädigte Bahnanlagen, ausgefallene Versorgung.">
+    <meta name="twitter:image" content="https://sprechfunk-uebung.de/assets/og-image.png">
+
+    <link rel="stylesheet" href="../../../bundle.css">
+    <link rel="stylesheet" href="../../../style.css">
+
+    <!-- GoatCounter: cookielose, anonyme Reichweitenmessung -->
+    <script data-goatcounter="https://sprechfunk-uebung.goatcounter.com/count"
+            async src="//gc.zgo.at/count.js"></script>
+
+    <script>
+        // Gleiche Theme-Auswahl wie in der App anwenden (statische Seiten laden kein Bundle).
+        document.addEventListener("DOMContentLoaded", function () {
+            var stored = localStorage.getItem("theme");
+            if (stored) {
+                document.body.setAttribute("data-theme", stored);
+            }
+        });
+    </script>
+</head>
+
+<body data-theme="light">
+<header class="app-header">
+    <div class="container app-header-grid">
+        <div class="app-header-title">
+            <p class="h2 mb-0">
+                <i class="fas fa-broadcast-tower"></i> Sprechfunk Übungsgenerator
+            </p>
+        </div>
+        <div class="app-header-actions d-none d-md-flex">
+            <a href="../../../" class="btn btn-primary">
+                <i class="fas fa-arrow-left"></i> Zur Anwendung
+            </a>
+            <a href="../../../anleitung/" class="btn btn-info">
+                <i class="fas fa-book"></i> Anleitung
+            </a>
+            <a href="https://github.com/wattnpapa/sprechfunk-uebung" class="btn btn-dark">
+                <i class="fab fa-github"></i> GitHub
+            </a>
+        </div>
+    </div>
+</header>
+
+<main class="container my-4 app-view-shell">
+    <nav aria-label="Brotkrumennavigation" class="mb-3">
+        <ol class="breadcrumb mb-0">
+            <li class="breadcrumb-item"><a href="../../../">Startseite</a></li>
+            <li class="breadcrumb-item"><a href="../../../funksprueche/">Funksprüche</a></li>
+            <li class="breadcrumb-item active" aria-current="page">Vorlage THW Lehrte</li>
+        </ol>
+    </nav>
+
+    <article>
+        <div class="card mb-3">
+            <div class="card-body">
+                <h1 class="h3">Funksprüche THW Lehrte: große Unwetterlage</h1>
+                <p class="mb-0">
+                    Mit <strong>752 Übungsnachrichten</strong> ist dies die größte Vorlage des
+                    Bestands. Sie beschreibt eine ausgedehnte Unwetterlage im Raum Lehrte und
+                    Burgdorf, in der mehrere Fachdienste und Organisationen gleichzeitig
+                    arbeiten.
+                </p>
+            </div>
+        </div>
+
+        <section class="card shadow-sm mb-4">
+            <div class="card-header"><h2 class="h4 mb-0" id="umfang-lage">Umfang und Zuschnitt der Lage</h2></div>
+            <div class="card-body">
+                <p>752 Nachrichten sind mehr, als ein Dienstabend braucht. Bei acht Funkstellen mit je acht Sprüchen sind 64 Nachrichten im Spiel – der Bestand trägt also rund zehn verschiedene Abende ohne Wiederholung.</p>
+                <p>Die Lage ist entsprechend breit angelegt. Überflutete Straßenzüge, beschädigte Bahnanlagen, ausgefallene Wasserversorgung und die Versorgung der eigenen Kräfte laufen parallel.</p>
+                <p class="mb-0">Für eine Stabsrahmenübung über zwei Tage ist das die passende Größe. Für den ersten Übungsabend nach dem Lehrgang ist sie zu schwer; dafür gibt es die Vorlage für die Grundausbildung.</p>
+            </div>
+        </section>
+
+        <section class="card shadow-sm mb-4">
+            <div class="card-header"><h2 class="h4 mb-0" id="laenge">Die längsten Texte im Archiv</h2></div>
+            <div class="card-body">
+                <p>Hier stehen die anspruchsvollsten Nachrichten des Bestands. Ein Beispiel im Wortlaut: <em>„8 Masten der Elektrifizierungsanlage am Bahnhof BURGDORF umgestürzt. Leitungen sind noch unter Spannung. Einsatz IZ erforderlich.“</em></p>
+                <p>Solche Texte tragen drei Informationen in einem Satz: Schadensbild, Gefahr und Auftrag. Wer davon einen Teil verliert, hat die Nachricht nicht aufgenommen, sondern nur gehört.</p>
+                <p class="mb-0">Deshalb gehört zu dieser Vorlage der <a href="../../../meldevordruck/">Meldevordruck</a> auf den Tisch. Aus dem Kopf lässt sich das nicht weitergeben.</p>
+            </div>
+        </section>
+
+        <section class="card shadow-sm mb-4">
+            <div class="card-header"><h2 class="h4 mb-0" id="organisationen">Mehrere Organisationen auf einer Rufgruppe</h2></div>
+            <div class="card-body">
+                <p>Ein Teil der Nachrichten spricht ausdrücklich andere Organisationen an. Eine davon: <em>„1 Löschzug LR der 1. FB sofort einsetzen Hildesheimer Alee. Dem dortigen Einsatzleiter unterstellen. Erreichen des Einsatzortes melden.“</em></p>
+                <p>Andere betreffen die zivile Versorgung, etwa die Anforderung von Verbandmaterial über Apotheken oder die Meldung von Transportraum für Trinkwasser.</p>
+                <p class="mb-0">Damit eignet sich die Vorlage für Übungen, an denen <a href="../../../funkuebung-katastrophenschutz/">mehrere Organisationen</a> teilnehmen. Die Rufnamen tragen die Teilnehmer selbst bei; der Generator übernimmt sie unverändert.</p>
+            </div>
+        </section>
+
+        <section class="card shadow-sm mb-4">
+            <div class="card-header"><h2 class="h4 mb-0" id="download">Herunterladen und im Generator nutzen</h2></div>
+            <div class="card-body">
+                <p>
+                    Die Datei enthält eine Nachricht je Zeile – genau das Format, das der
+                    Generator beim Upload liest. Herunterladen, im Generator
+                    <em>Eigene Datei hochladen</em> wählen, fertig.
+                </p>
+                <p>
+                    <a class="btn btn-primary" href="../../../assets/funksprueche-thw-lehrte.txt"
+                       download data-testid="download-txt">Alle 752 Funksprüche als Textdatei</a>
+                    <a class="btn btn-outline-primary" href="../../../">Übung erstellen</a>
+                </p>
+                <p class="mb-0">
+                    Die Nutzung steht unter der
+                    <a href="https://github.com/wattnpapa/sprechfunk-uebung/blob/main/LICENSE" target="_blank" rel="noopener noreferrer">EUPL-1.2</a>.
+                    Eigene Übungstexte nimmt das Projekt gern auf: an
+                    <a href="mailto:johannes.rudolph@thw-oldenburg.de">johannes.rudolph@thw-oldenburg.de</a>
+                    senden, eine Nachricht je Zeile.
+                </p>
+            </div>
+        </section>
+
+        <section class="card shadow-sm mb-4">
+            <div class="card-header"><h2 class="h4 mb-0" id="alle-funksprueche">Alle 752 Funksprüche dieser Vorlage</h2></div>
+            <div class="card-body">
+                <p>
+                    Der vollständige Bestand dieser Vorlage. Suche und Filter arbeiten im
+                    Browser; ohne JavaScript bleibt die Liste vollständig sichtbar.
+                </p>
+<!-- AP-08:LISTE -->
+            </div>
+        </section>
+    </article>
+</main>
+
+<footer class="main-footer">
+    <span class="footer-links">
+        <a href="../../../">Anwendung</a>
+        <a href="../../../anleitung/">Anleitung</a>
+        <a href="../../../buchstabiertafel/">Buchstabiertafel</a>
+        <a href="../../../meldevordruck/">Meldevordruck</a>
+        <a href="../../../funksprueche/">Funksprüche</a>
+        <a href="../../../faq/">FAQ</a>
+    </span>
+    <span class="footer-links">
+        <a href="../../../impressum/">Impressum</a>
+        <a href="../../../datenschutz/">Datenschutz</a>
+        <a href="mailto:johannes.rudolph@thw-oldenburg.de">Kontakt</a>
+        <a href="https://github.com/wattnpapa/sprechfunk-uebung" target="_blank" rel="noopener noreferrer">GitHub</a>
+        <a href="https://github.com/wattnpapa/sprechfunk-uebung/blob/main/LICENSE" target="_blank" rel="noopener noreferrer">EUPL-1.2-Lizenz</a>
+    </span>
+</footer>
+
+</body>
+
+</html>

--- a/src/pages/funksprueche-vorlage-thw-melle.html
+++ b/src/pages/funksprueche-vorlage-thw-melle.html
@@ -1,0 +1,176 @@
+<!DOCTYPE html>
+<html lang="de">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Funksprüche THW Melle: Stabsrahmen und Weser-Pegel üben</title>
+    <link rel="icon" type="image/png" href="../../../assets/favicon.png">
+    <link rel="canonical" href="https://sprechfunk-uebung.de/funksprueche/vorlage/thw-melle/">
+    <meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1">
+    <meta name="theme-color" content="#0d6efd">
+
+    <meta name="description" content="400 Übungsnachrichten mit hoher Fachdichte: Pegelmeldungen, Behandlungsplätze, Einsatzabschnitte, Kanalzuweisungen und Stärkemeldungen mehrerer Organisationen.">
+    <meta name="author" content="Johannes Rudolph">
+
+    <meta property="og:title" content="Funksprüche THW Melle: Stabsrahmen und Weser-Pegel üben">
+    <meta property="og:description" content="400 Übungsnachrichten mit hoher Fachdichte: Pegelmeldungen, Behandlungsplätze, Einsatzabschnitte, Kanalzuweisungen und Stärkemeldungen mehrerer Organisationen.">
+    <meta property="og:url" content="https://sprechfunk-uebung.de/funksprueche/vorlage/thw-melle/">
+    <meta property="og:type" content="article">
+    <meta property="og:locale" content="de_DE">
+    <meta property="og:site_name" content="Sprechfunk Übungsgenerator">
+    <meta property="og:image" content="https://sprechfunk-uebung.de/assets/og-image.png">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">
+    <meta property="og:image:alt" content="Sprechfunk Übungsgenerator – Übungen für den BOS-Sprechfunk erstellen">
+
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Funksprüche THW Melle: Stabsrahmen und Weser-Pegel üben">
+    <meta name="twitter:description" content="400 Übungsnachrichten mit hoher Fachdichte: Pegelmeldungen, Behandlungsplätze, Einsatzabschnitte, Kanalzuweisungen und Stärkemeldungen mehrerer Organisationen.">
+    <meta name="twitter:image" content="https://sprechfunk-uebung.de/assets/og-image.png">
+
+    <link rel="stylesheet" href="../../../bundle.css">
+    <link rel="stylesheet" href="../../../style.css">
+
+    <!-- GoatCounter: cookielose, anonyme Reichweitenmessung -->
+    <script data-goatcounter="https://sprechfunk-uebung.goatcounter.com/count"
+            async src="//gc.zgo.at/count.js"></script>
+
+    <script>
+        // Gleiche Theme-Auswahl wie in der App anwenden (statische Seiten laden kein Bundle).
+        document.addEventListener("DOMContentLoaded", function () {
+            var stored = localStorage.getItem("theme");
+            if (stored) {
+                document.body.setAttribute("data-theme", stored);
+            }
+        });
+    </script>
+</head>
+
+<body data-theme="light">
+<header class="app-header">
+    <div class="container app-header-grid">
+        <div class="app-header-title">
+            <p class="h2 mb-0">
+                <i class="fas fa-broadcast-tower"></i> Sprechfunk Übungsgenerator
+            </p>
+        </div>
+        <div class="app-header-actions d-none d-md-flex">
+            <a href="../../../" class="btn btn-primary">
+                <i class="fas fa-arrow-left"></i> Zur Anwendung
+            </a>
+            <a href="../../../anleitung/" class="btn btn-info">
+                <i class="fas fa-book"></i> Anleitung
+            </a>
+            <a href="https://github.com/wattnpapa/sprechfunk-uebung" class="btn btn-dark">
+                <i class="fab fa-github"></i> GitHub
+            </a>
+        </div>
+    </div>
+</header>
+
+<main class="container my-4 app-view-shell">
+    <nav aria-label="Brotkrumennavigation" class="mb-3">
+        <ol class="breadcrumb mb-0">
+            <li class="breadcrumb-item"><a href="../../../">Startseite</a></li>
+            <li class="breadcrumb-item"><a href="../../../funksprueche/">Funksprüche</a></li>
+            <li class="breadcrumb-item active" aria-current="page">Vorlage THW Melle</li>
+        </ol>
+    </nav>
+
+    <article>
+        <div class="card mb-3">
+            <div class="card-body">
+                <h1 class="h3">Funksprüche THW Melle: Stabsrahmen und Pegel</h1>
+                <p class="mb-0">
+                    Diese Vorlage enthält <strong>400 Übungsnachrichten</strong> mit der höchsten
+                    Fachdichte im Archiv. Sie stammt aus einer Hochwasserlage an der Weser und
+                    ist auf die Arbeit einer Führungsstelle zugeschnitten.
+                </p>
+            </div>
+        </div>
+
+        <section class="card shadow-sm mb-4">
+            <div class="card-header"><h2 class="h4 mb-0" id="fachdichte">Hohe Fachdichte, hoher Anspruch</h2></div>
+            <div class="card-body">
+                <p>Die Nachrichten dieser Vorlage arbeiten mit Abkürzungen und Fachbegriffen der Führungsebene. Ein Beispiel: <em>„Der UEAL MARTINSTOR wird der Funkkanal 455 in der Betriebsart U/G zugewiesen“</em>.</p>
+                <p>Wer die Abkürzungen nicht kennt, kann die Nachricht korrekt aufnehmen und trotzdem nicht handeln. Das ist kein Fehler der Vorlage, sondern ihr Zweck: sie richtet sich an Führungskräfte.</p>
+                <p class="mb-0">Für eine Sprechfunkausbildung für Führungskräfte ist das der passende Stoff. Für die erste Übung nach der Grundausbildung ist sie zu dicht.</p>
+            </div>
+        </section>
+
+        <section class="card shadow-sm mb-4">
+            <div class="card-header"><h2 class="h4 mb-0" id="meldearten">Wiederkehrende Meldearten</h2></div>
+            <div class="card-body">
+                <p>Vier Muster kommen häufig vor. Erstens die <strong>Pegelmeldung</strong>: <em>„Wasserstand der Weser am Pegel PORTA – WESTFALICA am 17060700 Höhe: 325 cm über Normal. Tendenz: Steigend“</em>.</p>
+                <p>Zweitens die <strong>Anforderung mit Zeitdruck</strong>, etwa ein dringend benötigtes Medikament für einen Behandlungsplatz. Drittens die <strong>Kanalzuweisung</strong> für einen Einsatzabschnitt.</p>
+                <p class="mb-0">Viertens die <strong>Stärkemeldung mit Fahrzeugen</strong>, die Personal und Material in einer Nachricht bündelt. Diese vier zusammen sind der Alltag einer Führungsstelle.</p>
+            </div>
+        </section>
+
+        <section class="card shadow-sm mb-4">
+            <div class="card-header"><h2 class="h4 mb-0" id="uebergreifend">Mehrere Organisationen im Verkehr</h2></div>
+            <div class="card-body">
+                <p>Die Lage bezieht Deutsches Rotes Kreuz und Feuerwehr ausdrücklich ein. Eine Nachricht meldet eine DRK-Gruppe an einer Schadenstelle, mit Stärke und Fahrzeugaufstellung in einem Satz.</p>
+                <p>Damit lässt sich üben, was im Einsatz regelmäßig vorkommt und selten geübt wird: Einheiten verschiedener Organisationen auf einer gemeinsamen Rufgruppe.</p>
+                <p class="mb-0">Die Funkrufnamen bringen die Teilnehmer selbst mit. Wie sie aufgebaut sind, steht unter <a href="../../../funkrufnamen/">Funkrufnamen</a>.</p>
+            </div>
+        </section>
+
+        <section class="card shadow-sm mb-4">
+            <div class="card-header"><h2 class="h4 mb-0" id="download">Herunterladen und im Generator nutzen</h2></div>
+            <div class="card-body">
+                <p>
+                    Die Datei enthält eine Nachricht je Zeile – genau das Format, das der
+                    Generator beim Upload liest. Herunterladen, im Generator
+                    <em>Eigene Datei hochladen</em> wählen, fertig.
+                </p>
+                <p>
+                    <a class="btn btn-primary" href="../../../assets/funksprueche-thw-melle.txt"
+                       download data-testid="download-txt">Alle 400 Funksprüche als Textdatei</a>
+                    <a class="btn btn-outline-primary" href="../../../">Übung erstellen</a>
+                </p>
+                <p class="mb-0">
+                    Die Nutzung steht unter der
+                    <a href="https://github.com/wattnpapa/sprechfunk-uebung/blob/main/LICENSE" target="_blank" rel="noopener noreferrer">EUPL-1.2</a>.
+                    Eigene Übungstexte nimmt das Projekt gern auf: an
+                    <a href="mailto:johannes.rudolph@thw-oldenburg.de">johannes.rudolph@thw-oldenburg.de</a>
+                    senden, eine Nachricht je Zeile.
+                </p>
+            </div>
+        </section>
+
+        <section class="card shadow-sm mb-4">
+            <div class="card-header"><h2 class="h4 mb-0" id="alle-funksprueche">Alle 400 Funksprüche dieser Vorlage</h2></div>
+            <div class="card-body">
+                <p>
+                    Der vollständige Bestand dieser Vorlage. Suche und Filter arbeiten im
+                    Browser; ohne JavaScript bleibt die Liste vollständig sichtbar.
+                </p>
+<!-- AP-08:LISTE -->
+            </div>
+        </section>
+    </article>
+</main>
+
+<footer class="main-footer">
+    <span class="footer-links">
+        <a href="../../../">Anwendung</a>
+        <a href="../../../anleitung/">Anleitung</a>
+        <a href="../../../buchstabiertafel/">Buchstabiertafel</a>
+        <a href="../../../meldevordruck/">Meldevordruck</a>
+        <a href="../../../funksprueche/">Funksprüche</a>
+        <a href="../../../faq/">FAQ</a>
+    </span>
+    <span class="footer-links">
+        <a href="../../../impressum/">Impressum</a>
+        <a href="../../../datenschutz/">Datenschutz</a>
+        <a href="mailto:johannes.rudolph@thw-oldenburg.de">Kontakt</a>
+        <a href="https://github.com/wattnpapa/sprechfunk-uebung" target="_blank" rel="noopener noreferrer">GitHub</a>
+        <a href="https://github.com/wattnpapa/sprechfunk-uebung/blob/main/LICENSE" target="_blank" rel="noopener noreferrer">EUPL-1.2-Lizenz</a>
+    </span>
+</footer>
+
+</body>
+
+</html>

--- a/src/pages/funksprueche-vorlage-thw-saarstedt.html
+++ b/src/pages/funksprueche-vorlage-thw-saarstedt.html
@@ -1,0 +1,176 @@
+<!DOCTYPE html>
+<html lang="de">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Funksprüche THW Saarstedt: Standorte buchstabieren üben</title>
+    <link rel="icon" type="image/png" href="../../../assets/favicon.png">
+    <link rel="canonical" href="https://sprechfunk-uebung.de/funksprueche/vorlage/thw-saarstedt/">
+    <meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1">
+    <meta name="theme-color" content="#0d6efd">
+
+    <meta name="description" content="200 kurze Übungsnachrichten mit Straßen- und Ortsnamen in Großbuchstaben: gemacht für das Buchstabieren nach der Buchstabiertafel und für Standortmeldungen.">
+    <meta name="author" content="Johannes Rudolph">
+
+    <meta property="og:title" content="Funksprüche THW Saarstedt: Standorte buchstabieren üben">
+    <meta property="og:description" content="200 kurze Übungsnachrichten mit Straßen- und Ortsnamen in Großbuchstaben: gemacht für das Buchstabieren nach der Buchstabiertafel und für Standortmeldungen.">
+    <meta property="og:url" content="https://sprechfunk-uebung.de/funksprueche/vorlage/thw-saarstedt/">
+    <meta property="og:type" content="article">
+    <meta property="og:locale" content="de_DE">
+    <meta property="og:site_name" content="Sprechfunk Übungsgenerator">
+    <meta property="og:image" content="https://sprechfunk-uebung.de/assets/og-image.png">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">
+    <meta property="og:image:alt" content="Sprechfunk Übungsgenerator – Übungen für den BOS-Sprechfunk erstellen">
+
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Funksprüche THW Saarstedt: Standorte buchstabieren üben">
+    <meta name="twitter:description" content="200 kurze Übungsnachrichten mit Straßen- und Ortsnamen in Großbuchstaben: gemacht für das Buchstabieren nach der Buchstabiertafel und für Standortmeldungen.">
+    <meta name="twitter:image" content="https://sprechfunk-uebung.de/assets/og-image.png">
+
+    <link rel="stylesheet" href="../../../bundle.css">
+    <link rel="stylesheet" href="../../../style.css">
+
+    <!-- GoatCounter: cookielose, anonyme Reichweitenmessung -->
+    <script data-goatcounter="https://sprechfunk-uebung.goatcounter.com/count"
+            async src="//gc.zgo.at/count.js"></script>
+
+    <script>
+        // Gleiche Theme-Auswahl wie in der App anwenden (statische Seiten laden kein Bundle).
+        document.addEventListener("DOMContentLoaded", function () {
+            var stored = localStorage.getItem("theme");
+            if (stored) {
+                document.body.setAttribute("data-theme", stored);
+            }
+        });
+    </script>
+</head>
+
+<body data-theme="light">
+<header class="app-header">
+    <div class="container app-header-grid">
+        <div class="app-header-title">
+            <p class="h2 mb-0">
+                <i class="fas fa-broadcast-tower"></i> Sprechfunk Übungsgenerator
+            </p>
+        </div>
+        <div class="app-header-actions d-none d-md-flex">
+            <a href="../../../" class="btn btn-primary">
+                <i class="fas fa-arrow-left"></i> Zur Anwendung
+            </a>
+            <a href="../../../anleitung/" class="btn btn-info">
+                <i class="fas fa-book"></i> Anleitung
+            </a>
+            <a href="https://github.com/wattnpapa/sprechfunk-uebung" class="btn btn-dark">
+                <i class="fab fa-github"></i> GitHub
+            </a>
+        </div>
+    </div>
+</header>
+
+<main class="container my-4 app-view-shell">
+    <nav aria-label="Brotkrumennavigation" class="mb-3">
+        <ol class="breadcrumb mb-0">
+            <li class="breadcrumb-item"><a href="../../../">Startseite</a></li>
+            <li class="breadcrumb-item"><a href="../../../funksprueche/">Funksprüche</a></li>
+            <li class="breadcrumb-item active" aria-current="page">Vorlage THW Saarstedt</li>
+        </ol>
+    </nav>
+
+    <article>
+        <div class="card mb-3">
+            <div class="card-body">
+                <h1 class="h3">Funksprüche THW Saarstedt: Standorte und Namen</h1>
+                <p class="mb-0">
+                    Diese Vorlage enthält <strong>200 kurze Übungsnachrichten</strong>, die fast
+                    alle einen Straßen- oder Ortsnamen in Großbuchstaben tragen. Sie ist damit
+                    die Buchstabier-Vorlage des Archivs.
+                </p>
+            </div>
+        </div>
+
+        <section class="card shadow-sm mb-4">
+            <div class="card-header"><h2 class="h4 mb-0" id="buchstabieren">Buchstabieren als Schwerpunkt</h2></div>
+            <div class="card-body">
+                <p>Buchstabieren lernt man nicht an einzelnen Wörtern, sondern an vielen. Diese Vorlage liefert die Menge: 200 Nachrichten, in denen fast immer ein Name in Großbuchstaben steht. Die Zeichen selbst stehen in der <a href="../../../buchstabiertafel/">Buchstabiertafel</a>.</p>
+                <p>Beispiele im Wortlaut: <em>„Haben Standort gewechselt. Neuer Standort ist TRIFTPLATZ.“</em>, <em>„Haben Einsatzstelle in LÖNSSTRASSE erreicht.“</em>, <em>„Sind auf dem Weg zu Einsatzstelle in HAYDNSTRASSE.“</em></p>
+                <p class="mb-0">Die Namen sind bewusst unhandlich. LÖNSSTRASSE verlangt den Umlaut und die Doppelkonsonanten, GIEBELSTIEG einen Wortteil, den man selten hört. Genau daran zeigt sich, ob die Tafel sitzt.</p>
+            </div>
+        </section>
+
+        <section class="card shadow-sm mb-4">
+            <div class="card-header"><h2 class="h4 mb-0" id="standortmeldung">Standortmeldungen als zweiter Zweck</h2></div>
+            <div class="card-body">
+                <p>Inhaltlich sind die Nachrichten Standort- und Bewegungsmeldungen. Sie sagen, wo eine Funkstelle ist, wohin sie fährt und wann sie angekommen ist.</p>
+                <p>Das ist im Einsatz die häufigste Meldung überhaupt und in Übungen unterrepräsentiert, weil sie unspektakulär wirkt. Eine Führungsstelle, die zehn Fahrzeuge im Blick behalten muss, sieht das anders.</p>
+                <p class="mb-0">Wer die Meldungen mitführt, übt nebenbei das Führen einer Lagekarte. Die Namen aus dem Bestand liegen im Raum Sarstedt südlich von Hannover.</p>
+            </div>
+        </section>
+
+        <section class="card shadow-sm mb-4">
+            <div class="card-header"><h2 class="h4 mb-0" id="kombinieren">Kombinieren und dosieren</h2></div>
+            <div class="card-body">
+                <p>Mit im Schnitt 62 Zeichen sind die Texte kurz. Der Aufwand liegt nicht in der Mitschrift, sondern im Buchstabieren, und lässt sich deshalb gut mit anderen Vorlagen mischen.</p>
+                <p>Eine bewährte Mischung ist diese Vorlage zusammen mit einer Unwetterlage: die kurzen Standortmeldungen füllen die Lücken zwischen den langen Lagemeldungen und halten den Kanal in Bewegung.</p>
+                <p class="mb-0">Zusätzlich lassen sich im Generator <strong>Lösungswörter</strong> einschalten. Dann kommt zu den Ortsnamen ein zu buchstabierendes Wort, das am Ende der Übung abgefragt wird.</p>
+            </div>
+        </section>
+
+        <section class="card shadow-sm mb-4">
+            <div class="card-header"><h2 class="h4 mb-0" id="download">Herunterladen und im Generator nutzen</h2></div>
+            <div class="card-body">
+                <p>
+                    Die Datei enthält eine Nachricht je Zeile – genau das Format, das der
+                    Generator beim Upload liest. Herunterladen, im Generator
+                    <em>Eigene Datei hochladen</em> wählen, fertig.
+                </p>
+                <p>
+                    <a class="btn btn-primary" href="../../../assets/funksprueche-thw-saarstedt.txt"
+                       download data-testid="download-txt">Alle 200 Funksprüche als Textdatei</a>
+                    <a class="btn btn-outline-primary" href="../../../">Übung erstellen</a>
+                </p>
+                <p class="mb-0">
+                    Die Nutzung steht unter der
+                    <a href="https://github.com/wattnpapa/sprechfunk-uebung/blob/main/LICENSE" target="_blank" rel="noopener noreferrer">EUPL-1.2</a>.
+                    Eigene Übungstexte nimmt das Projekt gern auf: an
+                    <a href="mailto:johannes.rudolph@thw-oldenburg.de">johannes.rudolph@thw-oldenburg.de</a>
+                    senden, eine Nachricht je Zeile.
+                </p>
+            </div>
+        </section>
+
+        <section class="card shadow-sm mb-4">
+            <div class="card-header"><h2 class="h4 mb-0" id="alle-funksprueche">Alle 200 Funksprüche dieser Vorlage</h2></div>
+            <div class="card-body">
+                <p>
+                    Der vollständige Bestand dieser Vorlage. Suche und Filter arbeiten im
+                    Browser; ohne JavaScript bleibt die Liste vollständig sichtbar.
+                </p>
+<!-- AP-08:LISTE -->
+            </div>
+        </section>
+    </article>
+</main>
+
+<footer class="main-footer">
+    <span class="footer-links">
+        <a href="../../../">Anwendung</a>
+        <a href="../../../anleitung/">Anleitung</a>
+        <a href="../../../buchstabiertafel/">Buchstabiertafel</a>
+        <a href="../../../meldevordruck/">Meldevordruck</a>
+        <a href="../../../funksprueche/">Funksprüche</a>
+        <a href="../../../faq/">FAQ</a>
+    </span>
+    <span class="footer-links">
+        <a href="../../../impressum/">Impressum</a>
+        <a href="../../../datenschutz/">Datenschutz</a>
+        <a href="mailto:johannes.rudolph@thw-oldenburg.de">Kontakt</a>
+        <a href="https://github.com/wattnpapa/sprechfunk-uebung" target="_blank" rel="noopener noreferrer">GitHub</a>
+        <a href="https://github.com/wattnpapa/sprechfunk-uebung/blob/main/LICENSE" target="_blank" rel="noopener noreferrer">EUPL-1.2-Lizenz</a>
+    </span>
+</footer>
+
+</body>
+
+</html>

--- a/src/pages/funksprueche.html
+++ b/src/pages/funksprueche.html
@@ -4,17 +4,17 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Funksprüche für Sprechfunkübungen: über 1.800 Texte</title>
+    <title>Funksprüche-Archiv: 3.684 Texte für Sprechfunkübungen</title>
     <link rel="icon" type="image/png" href="../assets/favicon.png">
     <link rel="canonical" href="https://sprechfunk-uebung.de/funksprueche/">
     <meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1">
     <meta name="theme-color" content="#0d6efd">
 
-    <meta name="description" content="Über 1.800 fertige Funksprüche für Sprechfunkübungen bei THW, Feuerwehr und Rettungsdienst, dazu eigene Vorlagen einbinden und Buchstabieraufgaben einbauen.">
+    <meta name="description" content="3.684 echte Übungsfunksprüche zum Durchsuchen und Herunterladen, sortiert nach Vorlage – für Sprechfunkübungen bei THW, Feuerwehr und Hilfsorganisationen.">
     <meta name="author" content="Johannes Rudolph">
 
-    <meta property="og:title" content="Funksprüche für Sprechfunkübungen: über 1.800 Texte">
-    <meta property="og:description" content="Über 1.800 fertige Funksprüche für Sprechfunkübungen bei THW, Feuerwehr und Rettungsdienst, dazu eigene Vorlagen einbinden und Buchstabieraufgaben einbauen.">
+    <meta property="og:title" content="Funksprüche-Archiv: 3.684 Texte für Sprechfunkübungen">
+    <meta property="og:description" content="3.684 echte Übungsfunksprüche zum Durchsuchen und Herunterladen, sortiert nach Vorlage – für Sprechfunkübungen bei THW, Feuerwehr und Hilfsorganisationen.">
     <meta property="og:url" content="https://sprechfunk-uebung.de/funksprueche/">
     <meta property="og:type" content="article">
     <meta property="og:locale" content="de_DE">
@@ -25,8 +25,8 @@
     <meta property="og:image:alt" content="Sprechfunk Übungsgenerator – Übungen für den BOS-Sprechfunk erstellen">
 
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Funksprüche für Sprechfunkübungen: über 1.800 Texte">
-    <meta name="twitter:description" content="Über 1.800 fertige Funksprüche für Sprechfunkübungen bei THW, Feuerwehr und Rettungsdienst, dazu eigene Vorlagen einbinden und Buchstabieraufgaben einbauen.">
+    <meta name="twitter:title" content="Funksprüche-Archiv: 3.684 Texte für Sprechfunkübungen">
+    <meta name="twitter:description" content="3.684 echte Übungsfunksprüche zum Durchsuchen und Herunterladen, sortiert nach Vorlage – für Sprechfunkübungen bei THW, Feuerwehr und Hilfsorganisationen.">
     <meta name="twitter:image" content="https://sprechfunk-uebung.de/assets/og-image.png">
 
     <link rel="stylesheet" href="../bundle.css">
@@ -85,12 +85,30 @@
                     Der zeitraubendste Teil einer <strong>Sprechfunkübung</strong> ist meist nicht
                     die Durchführung, sondern das Schreiben der Übungstexte. Der
                     <strong>Sprechfunk Übungsgenerator</strong> bringt deshalb
-                    <strong>über 1.800 fertige Funksprüche</strong> in mehreren Vorlagen mit und
+                    <strong>{{FUNKSPRUECHE_GESAMT}} fertige Funksprüche</strong> in mehreren Vorlagen mit und
                     verteilt sie automatisch auf die Teilnehmer – wahlweise ergänzt um eigene
                     Texte aus dem eigenen Ortsverband oder der eigenen Wache.
                 </p>
             </div>
         </div>
+
+        <section class="card shadow-sm mb-4">
+            <div class="card-header"><h2 class="h4 mb-0" id="archiv">Das Archiv: alle Vorlagen mit Anzahl</h2></div>
+            <div class="card-body">
+                <p>
+                    Der Bestand ist gewachsen, nicht generiert. Jede Vorlage stammt aus einer
+                    tatsächlich gefunkten Übung eines Ortsverbands. Über die Links unten steht
+                    jede Vorlage vollständig zum Durchblättern, Durchsuchen und Herunterladen
+                    bereit – {{FUNKSPRUECHE_ARCHIV}} Funksprüche im Wortlaut.
+                </p>
+<!-- AP-08:VORLAGEN -->
+                <p class="mb-0">
+                    Die humorvolle Vorlage ist im Generator wählbar, aber nicht Teil des
+                    öffentlichen Archivs: sie nennt fremde Marken und Figuren wörtlich, und das
+                    gehört nicht in ein Nachschlagewerk zum BOS-Sprechfunk.
+                </p>
+            </div>
+        </section>
 
         <div class="card mb-3">
             <div class="card-header"><h2 class="h4 mb-0" id="vorlagen">Mitgelieferte Vorlagen</h2></div>

--- a/src/pages/funktionen.html
+++ b/src/pages/funktionen.html
@@ -107,7 +107,7 @@
                         <p class="mb-0">
                             Die Übungstexte werden gleichmäßig auf alle Teilnehmer verteilt –
                             als Nachricht an einen einzelnen Empfänger, an mehrere Stellen oder
-                            an alle. Mitgeliefert sind über 1.800
+                            an alle. Mitgeliefert sind {{FUNKSPRUECHE_GESAMT}}
                             <a href="../funksprueche/">Funksprüche für Übungen</a>; eigene Texte
                             lassen sich als Textdatei hochladen.
                         </p>

--- a/src/pages/funkuebung-dienstabend.html
+++ b/src/pages/funkuebung-dienstabend.html
@@ -231,6 +231,15 @@
         </section>
 
         <section class="card shadow-sm mb-4">
+        <section class="card shadow-sm mb-4">
+            <div class="card-header"><h2 class="h4 mb-0" id="vorlage-einstieg">Welche Vorlage für den ersten Abend</h2></div>
+            <div class="card-body">
+                <p>Für einen ersten Dienstabend nach dem Lehrgang ist die Länge der Nachrichten die entscheidende Größe. Lange Texte binden die Aufmerksamkeit an den Stift.</p>
+                <p>Dafür liegt im Archiv die <a href="../funksprueche/vorlage/grundausbildung-einfach/">Vorlage für die Grundausbildung</a>: 462 kurze Meldungen, die Hälfte unter 50 Zeichen.</p>
+                <p class="mb-0">Damit schafft eine Funkstelle in einer Viertelstunde ein Dutzend Anrufe. Erst wenn das Verfahren sitzt, lohnt der Wechsel auf eine der längeren THW-Lagen.</p>
+            </div>
+        </section>
+
             <div class="card-header"><h2 class="h4 mb-0" id="puffer">Zeitpuffer einplanen</h2></div>
             <div class="card-body">
                 <p>Zehn Minuten Puffer am Ende verhindern, dass die Nachbesprechung ausfällt. Sie ist der Teil des Abends, an dem der Lerneffekt entsteht, und wird bei Zeitnot zuerst gestrichen.</p>

--- a/src/pages/funkuebung-feuerwehr.html
+++ b/src/pages/funkuebung-feuerwehr.html
@@ -157,7 +157,7 @@
                     </li>
                 </ul>
                 <p class="mb-0">
-                    Als Übungstexte stehen über 1.800
+                    Als Übungstexte stehen {{FUNKSPRUECHE_GESAMT}}
                     <a href="../funksprueche/">fertige Funksprüche</a> aus Einsatzlagen des
                     Bevölkerungs- und Katastrophenschutzes bereit – Unwetter, Hochwasser,
                     Erkundung, Logistik. Eigene Texte mit den Straßen, Objekten und Rufnamen aus

--- a/src/pages/funkuebung-katastrophenschutz.html
+++ b/src/pages/funkuebung-katastrophenschutz.html
@@ -155,7 +155,7 @@
                     </li>
                 </ul>
                 <p class="mb-0">
-                    Über 1.800 <a href="../funksprueche/">fertige Funksprüche</a> aus
+                    {{FUNKSPRUECHE_GESAMT}} <a href="../funksprueche/">fertige Funksprüche</a> aus
                     Katastrophenschutz-Lagen – Hochwasser, Unwetter, Erkundung, Logistik,
                     Betreuung – liegen bei; eigene Texte lassen sich als Textdatei ergänzen.
                 </p>
@@ -212,6 +212,15 @@
         </section>
 
         <section class="card shadow-sm mb-4">
+        <section class="card shadow-sm mb-4">
+            <div class="card-header"><h2 class="h4 mb-0" id="vorlagen-uebergreifend">Vorlagen mit mehreren Organisationen</h2></div>
+            <div class="card-body">
+                <p>Zwei Vorlagen im Archiv sprechen mehrere Organisationen ausdrücklich an, statt sie nur mitzudenken.</p>
+                <p>Die <a href="../funksprueche/vorlage/thw-lehrte/">Unwetterlage aus Lehrte</a> enthält Aufträge an Feuerwehreinheiten und Meldungen zur zivilen Versorgung, etwa Verbandmaterial über Apotheken und Transportraum für Trinkwasser.</p>
+                <p class="mb-0">Die <a href="../funksprueche/vorlage/thw-essen/">Hochwasserlage aus Essen</a> übt Erkundung mit Rückmeldung, Stärkemeldungen und Koordinaten im UTM-Format – Dinge, die in gemeinsamen Übungen regelmäßig schiefgehen.</p>
+            </div>
+        </section>
+
             <div class="card-header"><h2 class="h4 mb-0" id="rufgruppe">Rufgruppe für die gemeinsame Übung</h2></div>
             <div class="card-body">
                 <p>Bei organisationsübergreifenden Übungen muss die Rufgruppe vorher abgestimmt sein. Zwei Einheiten auf verschiedenen Gruppen hören sich nicht, und das fällt erst nach der ersten unbeantworteten Anrufantwort auf.</p>

--- a/src/pages/funkuebung-planen.html
+++ b/src/pages/funkuebung-planen.html
@@ -152,7 +152,7 @@
             <div class="card-body">
                 <p>
                     Jetzt kommt der Inhalt: Welche Nachrichten werden gesendet? Der Generator
-                    bringt über 1.800 <a href="../funksprueche/">fertige Funksprüche</a> mit –
+                    bringt {{FUNKSPRUECHE_GESAMT}} <a href="../funksprueche/">fertige Funksprüche</a> mit –
                     kuratiert aus echten Übungen, von kurzen Betriebsmeldungen bis zu
                     Lagemeldungen mit Zahlen, Orten und Namen. Alternativ lädst du eigene
                     Texte als Textdatei hoch, etwa passend zu einem

--- a/src/pages/funkuebung-szenarien.html
+++ b/src/pages/funkuebung-szenarien.html
@@ -235,7 +235,7 @@
                     </li>
                     <li>
                         <strong>Sprüche zum Szenario passend wählen:</strong> Eigene Texte
-                        zur Lage hochladen oder aus den über 1.800
+                        zur Lage hochladen oder aus den {{FUNKSPRUECHE_GESAMT}}
                         <a href="../funksprueche/">Funksprüchen</a> die passenden Kategorien
                         wählen – ein Deichläufer meldet keine Kellerbrände.
                     </li>
@@ -286,6 +286,15 @@
         </section>
 
         <section class="card shadow-sm mb-4">
+        <section class="card shadow-sm mb-4">
+            <div class="card-header"><h2 class="h4 mb-0" id="vorlagen-zum-szenario">Passende Vorlagen zu diesen Szenarien</h2></div>
+            <div class="card-body">
+                <p>Für die beiden Lagearten gibt es im Archiv je einen erprobten Bestand. Die <a href="../funksprueche/vorlage/thw-leer/">Sturmlage aus Ostfriesland</a> ist eine Flächenlage: viele kleine Einsatzstellen, verteilt über ein großes Gebiet.</p>
+                <p>Wer eine Lage über mehrere Stunden oder Tage tragen will, nimmt die <a href="../funksprueche/vorlage/thw-lehrte/">große Unwetterlage aus Lehrte</a>. Mit 752 Nachrichten reicht sie für rund zehn Abende ohne Wiederholung.</p>
+                <p class="mb-0">Beide lassen sich als Textdatei herunterladen und im Generator wie eine mitgelieferte Vorlage verwenden.</p>
+            </div>
+        </section>
+
             <div class="card-header"><h2 class="h4 mb-0" id="passung">Szenario und Teilnehmerzahl zusammendenken</h2></div>
             <div class="card-body">
                 <p>Ein Szenario mit vielen Einsatzstellen braucht viele Funkstellen, sonst bleibt die Lage blass. Umgekehrt erzeugt eine Einsatzlage mit zwei beteiligten Stellen bei zehn Teilnehmern Langeweile.</p>

--- a/src/pages/funkuebung-thw.html
+++ b/src/pages/funkuebung-thw.html
@@ -190,7 +190,7 @@
             <div class="card-header"><h2 class="h4 mb-0" id="vorlagen">THW-Funksprüche aus echten Übungen</h2></div>
             <div class="card-body">
                 <p>
-                    Die Anwendung bringt <strong>über 1.800 fertige Funksprüche</strong> mit,
+                    Die Anwendung bringt <strong>{{FUNKSPRUECHE_GESAMT}} fertige Funksprüche</strong> mit,
                     darunter mehrere Vorlagen, die in THW-Ortsverbänden für
                     Standortübungen geschrieben wurden. Typische Texte:
                 </p>
@@ -263,6 +263,15 @@
         </section>
 
         <section class="card shadow-sm mb-4">
+        <section class="card shadow-sm mb-4">
+            <div class="card-header"><h2 class="h4 mb-0" id="vorlagen-ortsverbaende">Aus welchen Ortsverbänden die Vorlagen stammen</h2></div>
+            <div class="card-body">
+                <p>Die mitgelieferten THW-Vorlagen sind keine Redaktionsarbeit, sondern gefunkte Übungen. Fünf Ortsverbände haben ihre Lagen beigesteuert, und jede lässt sich vollständig durchblättern.</p>
+                <p>Zur Auswahl stehen <a href="../funksprueche/vorlage/thw-lehrte/">752 Nachrichten aus Lehrte</a> als große Unwetterlage, <a href="../funksprueche/vorlage/thw-melle/">400 Nachrichten aus Melle</a> mit Stabsrahmen und Pegelmeldungen sowie <a href="../funksprueche/vorlage/thw-saarstedt/">200 Standortmeldungen aus Saarstedt</a> zum Buchstabieren.</p>
+                <p class="mb-0">Kleiner, aber zugeschnitten sind <a href="../funksprueche/vorlage/thw-essen/">92 Nachrichten aus Essen</a> zu einem Deichbruch an der Emscher und <a href="../funksprueche/vorlage/thw-leer/">118 Nachrichten aus Leer</a> zu einer Sturmlage in Ostfriesland. Wer eigene Lagen beisteuern will, schickt sie als Textdatei an das Projekt.</p>
+            </div>
+        </section>
+
             <div class="card-header"><h2 class="h4 mb-0" id="staerkemeldungen">Stärkemeldungen als Zahlenübung</h2></div>
             <div class="card-body">
                 <p>Die Stärkemeldung ist die dankbarste Zahlenübung im THW, weil sie im Einsatz ständig vorkommt. Aus den Vorlagen stammt etwa: „Unsere Stärke ist 1/2/9//12.“</p>

--- a/src/pages/funkuebung-vorlage.html
+++ b/src/pages/funkuebung-vorlage.html
@@ -86,7 +86,7 @@
                     meist starre PDFs: einmal heruntergeladen, dreimal verwendet, dann kennt
                     jeder in der Einheit die Funksprüche auswendig. Der
                     <strong>Sprechfunk Übungsgenerator</strong> geht einen Schritt weiter: Er
-                    erzeugt aus über 1.800 Übungstexten <strong>jedes Mal eine neue, komplette
+                    erzeugt aus {{FUNKSPRUECHE_GESAMT}} Übungstexten <strong>jedes Mal eine neue, komplette
                     Sprechfunkübung als PDF</strong> – zugeschnitten auf deine Teilnehmerzahl
                     und deine Rufnamen. Kostenlos, ohne Anmeldung, ohne Installation.
                 </p>
@@ -185,7 +185,7 @@
             <div class="card-body">
                 <p>Eine PDF-Vorlage enthält feste Texte in fester Reihenfolge. Beim zweiten Einsatz erkennen die Teilnehmer die Sprüche wieder, beim dritten kennen sie die Reihenfolge. Damit übt die Übung das Erinnern statt das Aufnehmen.</p>
                 <p>Dazu kommt die Zuordnung. Eine Vorlage für acht Funkstellen passt nicht auf sechs, und sie kennt die Rufnamen des Ortsverbands nicht. Wer sie anpasst, schreibt sie halb neu.</p>
-                <p>Der Generator dreht das um: Die Verteilung entsteht aus der Teilnehmerliste, die Texte aus einer Vorlage mit über 1.800 Sprüchen. Zwei Übungen mit denselben Einstellungen sind trotzdem verschieden.</p>
+                <p>Der Generator dreht das um: Die Verteilung entsteht aus der Teilnehmerliste, die Texte aus einer Vorlage mit {{FUNKSPRUECHE_GESAMT}} Sprüchen. Zwei Übungen mit denselben Einstellungen sind trotzdem verschieden.</p>
             </div>
         </section>
 
@@ -216,6 +216,15 @@
         </section>
 
         <section class="card shadow-sm mb-4">
+        <section class="card shadow-sm mb-4">
+            <div class="card-header"><h2 class="h4 mb-0" id="archiv-durchblaettern">Die Vorlagen vorher durchblättern</h2></div>
+            <div class="card-body">
+                <p>Wer wissen will, was in einer Vorlage steht, muss keine Übung erzeugen. Der Bestand liegt vollständig offen und ist durchsuchbar.</p>
+                <p>Für den Einstieg eignet sich die <a href="../funksprueche/vorlage/grundausbildung-einfach/">Sammlung kurzer Meldungen aus der Grundausbildung</a>, für Führungskräfte die <a href="../funksprueche/vorlage/thw-melle/">fachdichte Lage aus Melle</a>.</p>
+                <p class="mb-0">Jede Vorlage lässt sich als Textdatei herunterladen und unverändert wieder hochladen. Damit ist auch nachvollziehbar, was der Generator verteilt.</p>
+            </div>
+        </section>
+
             <div class="card-header"><h2 class="h4 mb-0" id="drucken">Unterlagen rechtzeitig drucken</h2></div>
             <div class="card-body">
                 <p>Der Druck der Unterlagen dauert bei zehn Funkstellen einige Minuten. Wer die ZIP-Datei erst am Übungsabend öffnet, verliert diese Zeit vor der Einweisung.</p>

--- a/src/pages/open-source.html
+++ b/src/pages/open-source.html
@@ -100,7 +100,7 @@
                     Es gibt <strong>keine Preisstufen und keine Premium-Funktionen</strong>:
                     Jede Wehr, jeder Ortsverband und jede Bereitschaft nutzt denselben
                     vollen Funktionsumfang –
-                    <a href="../funksprueche/">über 1.800 Funksprüche</a>, PDF-Vordrucke,
+                    <a href="../funksprueche/">{{FUNKSPRUECHE_GESAMT}} Funksprüche</a>, PDF-Vordrucke,
                     Teilnehmer-Links und die
                     <a href="../regiebuch-funkuebung/">Live-Übungsleitung</a>.
                 </p>

--- a/src/pages/regiebuch-funkuebung.html
+++ b/src/pages/regiebuch-funkuebung.html
@@ -216,6 +216,15 @@
         </section>
 
         <section class="card shadow-sm mb-4">
+        <section class="card shadow-sm mb-4">
+            <div class="card-header"><h2 class="h4 mb-0" id="vorlage-fuehrungsstelle">Eine Vorlage für die Führungsstelle</h2></div>
+            <div class="card-body">
+                <p>Wer den Nachrichtenplan aus der Sicht einer Führungsstelle üben will, braucht Nachrichten mit Führungsinhalt. Standortmeldungen genügen dafür nicht.</p>
+                <p>Im Archiv liegt dafür die <a href="../funksprueche/vorlage/thw-melle/">Vorlage aus Melle</a>: 400 Nachrichten mit Pegelmeldungen, Behandlungsplätzen, Einsatzabschnitten und Kanalzuweisungen.</p>
+                <p class="mb-0">Sie ist die fachdichteste des Bestands und setzt Kenntnis der Abkürzungen voraus. Für die Grundausbildung ist sie zu schwer, für eine Stabsrahmenübung genau richtig.</p>
+            </div>
+        </section>
+
             <div class="card-header"><h2 class="h4 mb-0" id="notizen">Notizen während der Übung</h2></div>
             <div class="card-body">
                 <p>Die Übungsleitung kann zu jeder Nachricht eine Notiz setzen. Bewährt hat sich, nicht den Fehler zu notieren, sondern den Wortlaut: Was genau wurde gesagt, statt der Bewertung.</p>

--- a/src/pages/sprechfunk-regeln.html
+++ b/src/pages/sprechfunk-regeln.html
@@ -313,7 +313,7 @@
                     Anruf, Betriebsworte und Buchstabieren sitzen erst, wenn sie regelmäßig
                     unter leichtem Druck angewendet werden. Genau dafür gibt es den
                     Sprechfunk Übungsgenerator: Er verteilt
-                    <a href="../funksprueche/">über 1.800 Funksprüche</a> auf die Teilnehmer,
+                    <a href="../funksprueche/">{{FUNKSPRUECHE_GESAMT}} Funksprüche</a> auf die Teilnehmer,
                     erzeugt Vordrucke und Regiebuch und begleitet die Übung live – vom
                     kurzen <a href="../funkuebung-dienstabend/">Dienstabend</a> bis zur
                     <a href="../funkuebung-szenarien/">eingekleideten Szenario-Übung</a>.

--- a/tests/seo/FunkspruchArchiv.test.ts
+++ b/tests/seo/FunkspruchArchiv.test.ts
@@ -1,0 +1,287 @@
+import { readFileSync, readdirSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { SITE_PAGES } from "../../scripts/site-pages.mjs";
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore -- reine JS-Hilfsmodule ohne Typdeklarationen, absichtlich .mjs
+import {
+    ARCHIV_VORLAGEN,
+    baueBestand,
+    funkspruchId,
+    hatBuchstabieranteil,
+    kategorieFuer,
+    parseVorlage,
+    schwierigkeitFuer,
+    VORLAGEN
+} from "../../scripts/lib/funkspruch-daten.mjs";
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+import { ANZAHL_ARCHIV, ANZAHL_GESAMT, ANZAHL_GESAMT_TEXT, BESTAND } from "../../scripts/lib/funkspruch-bestand.mjs";
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+import { downloadDateiname, renderFunkspruchListe, txtInhalt } from "../../scripts/lib/funkspruch-seiten.mjs";
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+import { ersetzeBestandszahlen } from "../../scripts/lib/render-page.mjs";
+
+const ROOT = path.resolve(__dirname, "..", "..");
+const VORLAGEN_DIR = path.join(ROOT, "assets", "funksprueche");
+
+interface Vorlage { datei: string; slug: string; name: string; imArchiv?: boolean }
+interface Eintrag {
+    id: string; text: string; vorlage: string; kategorie: string;
+    organisation: string[]; schwierigkeit: string; buchstabieren: boolean; zeichen: number;
+}
+
+/**
+ * Unabhängige Zählung der Quelldateien. Absichtlich nicht über das zu prüfende
+ * Modul: sonst würde der Test dieselbe Annahme zweimal bestätigen.
+ */
+const zaehleZeilen = (datei: string): number =>
+    readFileSync(path.join(VORLAGEN_DIR, datei), "utf8")
+        .split(/\r?\n/)
+        .filter(zeile => zeile.trim() !== "")
+        .length;
+
+describe("Bestand deckt die Quelldateien vollständig ab", () => {
+    it("führt jede Datei unter assets/funksprueche/ in VORLAGEN", () => {
+        const imVerzeichnis = readdirSync(VORLAGEN_DIR).filter(name => name.endsWith(".txt")).sort();
+        const inRegistry = (VORLAGEN as Vorlage[]).map(vorlage => vorlage.datei).sort();
+        expect(inRegistry).toEqual(imVerzeichnis);
+    });
+
+    it.each((VORLAGEN as Vorlage[]).map(vorlage => [vorlage.slug, vorlage] as const))(
+        "%s enthält genau so viele Einträge wie die Quelldatei Zeilen",
+        (_slug, vorlage) => {
+            const eintraege = BESTAND.nachVorlage.get(vorlage.slug) as Eintrag[];
+            expect(eintraege.length).toBe(zaehleZeilen(vorlage.datei));
+        }
+    );
+
+    it("summiert die Einzelzählungen zur Gesamtzahl", () => {
+        const summe = (VORLAGEN as Vorlage[])
+            .reduce((wert, vorlage) => wert + zaehleZeilen(vorlage.datei), 0);
+        expect(ANZAHL_GESAMT).toBe(summe);
+    });
+
+    it("zählt je Datei und nicht über cat, weil eine Datei ohne Zeilenumbruch endet", () => {
+        // nachrichten_thw_melle.txt endet ohne \n. Über `cat *.txt` verklebt ihre
+        // letzte Zeile mit der ersten der Folgedatei – die dokumentierte Zählung
+        // lag deshalb um eins zu niedrig. Dieser Test hält die Ursache fest.
+        const roh = readFileSync(path.join(VORLAGEN_DIR, "nachrichten_thw_melle.txt"), "utf8");
+        expect(roh.endsWith("\n")).toBe(false);
+
+        const verklebt = (VORLAGEN as Vorlage[])
+            .map(vorlage => readFileSync(path.join(VORLAGEN_DIR, vorlage.datei), "utf8"))
+            .join("")
+            .split(/\r?\n/)
+            .filter(zeile => zeile.trim() !== "")
+            .length;
+        expect(verklebt).toBe(ANZAHL_GESAMT - 1);
+    });
+
+    it("wirft, wenn eine Vorlage fehlt", () => {
+        expect(() => baueBestand({})).toThrow(/fehlt/);
+    });
+});
+
+describe("Kennungen sind stabil", () => {
+    it("liefert für denselben Text dieselbe Kennung", () => {
+        expect(funkspruchId("Sind einsatzbereit.")).toBe(funkspruchId("Sind einsatzbereit."));
+    });
+
+    it("erzeugt über zwei Läufe mit gleichem Eingang identische Kennungen", () => {
+        const inhalte: Record<string, string> = {};
+        for (const vorlage of VORLAGEN as Vorlage[]) {
+            inhalte[vorlage.datei] = readFileSync(path.join(VORLAGEN_DIR, vorlage.datei), "utf8");
+        }
+        const ersterLauf = (baueBestand(inhalte).alle as Eintrag[]).map(eintrag => eintrag.id);
+        const zweiterLauf = (baueBestand(inhalte).alle as Eintrag[]).map(eintrag => eintrag.id);
+        expect(zweiterLauf).toEqual(ersterLauf);
+    });
+
+    it("hängt allein am Text, nicht an Vorlage oder Reihenfolge", () => {
+        const [a] = parseVorlage({ slug: "eine", organisation: ["thw"] }, "Verstanden.") as Eintrag[];
+        const [b] = parseVorlage({ slug: "andere", organisation: ["allgemein"] }, "Verstanden.") as Eintrag[];
+        expect(a!.id).toBe(b!.id);
+    });
+
+    it("vergibt im ganzen Bestand keine Kennung doppelt", () => {
+        const ids = (BESTAND.alle as Eintrag[]).map(eintrag => eintrag.id);
+        expect(new Set(ids).size).toBe(ids.length);
+    });
+
+    it("liefert zwölf Hexzeichen", () => {
+        expect(funkspruchId("Sind einsatzbereit.")).toMatch(/^[0-9a-f]{12}$/);
+    });
+});
+
+describe("Ableitungen je Funkspruch", () => {
+    it("übernimmt die Stufe der Vorlage, wenn sie benannt ist", () => {
+        expect(schwierigkeitFuer("x".repeat(300), { schwierigkeit: "einfach" })).toBe("einfach");
+    });
+
+    it("leitet die Stufe sonst aus der Textlänge ab", () => {
+        expect(schwierigkeitFuer("Sind einsatzbereit.", {})).toBe("einfach");
+        expect(schwierigkeitFuer("x".repeat(120), {})).toBe("mittel");
+        expect(schwierigkeitFuer("x".repeat(200), {})).toBe("schwer");
+    });
+
+    it("erkennt Wörter in Großbuchstaben als Buchstabieranteil", () => {
+        expect(hatBuchstabieranteil("Neuer Standort ist TRIFTPLATZ.")).toBe(true);
+        expect(hatBuchstabieranteil("Sind einsatzbereit.")).toBe(false);
+    });
+
+    it("ordnet nur bei klarem Treffer zu, sonst allgemein", () => {
+        expect(kategorieFuer("Der Pegel steigt weiter.")).toBe("unwetter-hochwasser");
+        expect(kategorieFuer("Erkunden Sie das Gebiet.")).toBe("erkundung");
+        expect(kategorieFuer("Stärke: 0/1/1//2")).toBe("staerkemeldung");
+        expect(kategorieFuer("Verstanden.")).toBe("allgemein");
+    });
+
+    it("liefert für jeden Eintrag alle Pflichtfelder", () => {
+        const eintraege = parseVorlage(
+            { slug: "test", organisation: ["thw"] },
+            "Haben Einsatzstelle in LÖNSSTRASSE erreicht.\n\n"
+        ) as Eintrag[];
+        expect(eintraege).toHaveLength(1);
+        expect(eintraege[0]).toMatchObject({
+            text: "Haben Einsatzstelle in LÖNSSTRASSE erreicht.",
+            vorlage: "test",
+            organisation: ["thw"],
+            buchstabieren: true,
+            zeichen: 44
+        });
+        expect(eintraege[0]!.id).toMatch(/^[0-9a-f]{12}$/);
+    });
+});
+
+describe("Öffentliches Archiv", () => {
+    it("lässt die humorvolle Vorlage bewusst aus", () => {
+        const slugs = (ARCHIV_VORLAGEN as Vorlage[]).map(vorlage => vorlage.slug);
+        expect(slugs).not.toContain("lustig-kreativ");
+        // Im Generator bleibt sie verfügbar: sie steht weiter in VORLAGEN.
+        expect((VORLAGEN as Vorlage[]).map(vorlage => vorlage.slug)).toContain("lustig-kreativ");
+    });
+
+    it("führt für jede Archivvorlage genau eine Seite in der Registry", () => {
+        const seiten = (SITE_PAGES as { archivVorlage?: string }[])
+            .filter(seite => seite.archivVorlage !== undefined)
+            .map(seite => seite.archivVorlage as string);
+        expect(seiten.sort()).toEqual((ARCHIV_VORLAGEN as Vorlage[]).map(v => v.slug).sort());
+    });
+
+    it("zeigt weniger Einträge als der Generator verteilt", () => {
+        expect(ANZAHL_ARCHIV).toBeLessThan(ANZAHL_GESAMT);
+        expect(ANZAHL_ARCHIV).toBe(
+            (ARCHIV_VORLAGEN as Vorlage[]).reduce((wert, v) => wert + zaehleZeilen(v.datei), 0)
+        );
+    });
+
+    it("hält jede Archivseite über der Mindestzahl von zehn Einträgen", () => {
+        for (const vorlage of ARCHIV_VORLAGEN as Vorlage[]) {
+            expect((BESTAND.nachVorlage.get(vorlage.slug) as Eintrag[]).length,
+                `${vorlage.slug} zu klein für eine eigene URL`).toBeGreaterThanOrEqual(10);
+        }
+    });
+});
+
+describe("Ausgeliefertes Markup und Download", () => {
+    const beispiel: Eintrag[] = [
+        {
+            id: "abc123abc123", text: "Sind einsatzbereit.", vorlage: "test",
+            kategorie: "allgemein", organisation: ["thw"], schwierigkeit: "einfach",
+            buchstabieren: false, zeichen: 19
+        },
+        {
+            id: "def456def456", text: "Neuer Standort ist TRIFTPLATZ.", vorlage: "test",
+            kategorie: "standortmeldung", organisation: ["thw"], schwierigkeit: "einfach",
+            buchstabieren: true, zeichen: 30
+        }
+    ];
+
+    it("schreibt jeden Funkspruch mit stabilem Anker in die Liste", () => {
+        const html = renderFunkspruchListe(beispiel);
+        expect(html).toContain('id="fs-abc123abc123"');
+        expect(html).toContain("Sind einsatzbereit.");
+        expect(html).toContain('data-kategorie="standortmeldung"');
+        // Stufe und Buchstabieranteil stehen sichtbar, nicht als Attribut:
+        // 752-mal ein ungelesenes data-Attribut kostete über 20 KB Seitengröße.
+        expect(html).toContain("einfach · 30 Zeichen · buchstabieren");
+        expect(html).not.toContain("data-buchstabieren");
+    });
+
+    it("hält das Markup je Eintrag knapp", () => {
+        // Regressionsschutz für die Seitengröße: die größte Archivseite lag mit
+        // fettem Markup bei 333 KB und damit über der Grenze von 300 KB.
+        // Gemessen sind 177 Zeichen Rahmen je Eintrag, davon der größte Teil die
+        // sichtbare Merkmalzeile. Vor der Verschlankung waren es rund 266.
+        const eintrag = { ...beispiel[0]!, text: "x".repeat(100) };
+        const zeile = renderFunkspruchListe([eintrag]).split("\n")[1] ?? "";
+        expect(zeile.length - 100).toBeLessThan(200);
+    });
+
+    it("maskiert Sonderzeichen im Funkspruchtext", () => {
+        const html = renderFunkspruchListe([{ ...beispiel[0]!, text: 'Keller <5 m² & "nass"' }]);
+        expect(html).toContain("&lt;5 m² &amp;");
+        expect(html).not.toContain("<5 m²");
+    });
+
+    it("liefert den Download im Upload-Format: eine Nachricht je Zeile", () => {
+        expect(txtInhalt(beispiel)).toBe("Sind einsatzbereit.\nNeuer Standort ist TRIFTPLATZ.\n");
+    });
+
+    it("erzeugt aus dem echten Bestand eine Datei ohne Leerzeilen", () => {
+        for (const vorlage of ARCHIV_VORLAGEN as Vorlage[]) {
+            const eintraege = BESTAND.nachVorlage.get(vorlage.slug) as Eintrag[];
+            const zeilen = txtInhalt(eintraege).split("\n");
+            // Letztes Element ist der abschließende Zeilenumbruch.
+            expect(zeilen.pop()).toBe("");
+            expect(zeilen).toHaveLength(eintraege.length);
+            expect(zeilen.every(zeile => zeile.trim() !== "")).toBe(true);
+        }
+    });
+
+    it("benennt die Downloads nach ihrer Vorlage", () => {
+        expect(downloadDateiname("thw-lehrte")).toBe("funksprueche-thw-lehrte.txt");
+    });
+});
+
+describe("Die ausgewiesene Anzahl stammt aus dem gezählten Bestand", () => {
+    const leseSeite = (name: string) => readFileSync(path.join(ROOT, "src", "pages", name), "utf8");
+
+    it("führt nirgends mehr die veraltete Zahl 1.800", () => {
+        for (const name of readdirSync(path.join(ROOT, "src", "pages"))) {
+            if (!name.endsWith(".html")) continue;
+            expect(leseSeite(name), `${name} nennt noch 1.800`).not.toContain("1.800");
+        }
+        expect(readFileSync(path.join(ROOT, "src", "index.html"), "utf8")).not.toContain("1.800");
+    });
+
+    it("nennt im Titel der Übersichtsseite genau die berechnete Zahl", () => {
+        const html = leseSeite("funksprueche.html");
+        const titel = /<title>([^<]*)<\/title>/i.exec(html)?.[1] ?? "";
+        const description = /<meta name="description" content="([^"]*)"/i.exec(html)?.[1] ?? "";
+        expect(titel).toContain(ANZAHL_GESAMT_TEXT);
+        expect(description).toContain(ANZAHL_GESAMT_TEXT);
+    });
+
+    it("löst den Platzhalter im Fließtext gegen den Bestand auf", () => {
+        const ergebnis = ersetzeBestandszahlen(
+            "<p>{{FUNKSPRUECHE_GESAMT}} Funksprüche, davon {{FUNKSPRUECHE_ARCHIV}} im Archiv.</p>",
+            { anzahlGesamt: 1234, anzahlArchiv: 567 }
+        );
+        expect(ergebnis).toBe("<p>1.234 Funksprüche, davon 567 im Archiv.</p>");
+    });
+
+    it("bricht ab, wenn ein Platzhalter ohne Bestand aufgelöst werden soll", () => {
+        expect(() => ersetzeBestandszahlen("<p>{{FUNKSPRUECHE_GESAMT}}</p>", null))
+            .toThrow(/kein Bestand/);
+    });
+
+    it("lässt Seiten ohne Platzhalter unverändert", () => {
+        expect(ersetzeBestandszahlen("<p>ohne Zahl</p>", null)).toBe("<p>ohne Zahl</p>");
+    });
+});

--- a/tests/seo/Lastmod.test.ts
+++ b/tests/seo/Lastmod.test.ts
@@ -188,10 +188,13 @@ describe("lastmod im echten Repository", () => {
     // Einmal für alle 27 Seiten ermitteln: je Seite ein git-Aufruf, das dauert
     // im echten Repo länger als der Standard-Timeout eines einzelnen Tests.
     const werte: Record<string, string | null> = {};
+    /** Alle Commit-Zeitpunkte je Seite – ebenfalls zu langsam für einen Einzeltest. */
+    const zeitenProSeite: Record<string, Set<string>> = {};
 
     beforeAll(async () => {
         for (const seite of SITEMAP_PAGES as { slug: string; sources: string[] }[]) {
             werte[seite.slug] = await resolveLastmod(seite, projektGit);
+            zeitenProSeite[seite.slug] = commitZeiten(seite);
         }
     }, 120_000);
 
@@ -243,12 +246,66 @@ describe("lastmod im echten Repository", () => {
             .toBeGreaterThan(1);
     });
 
-    it("schreibt nicht das Build-Datum in alle URLs", () => {
+    /**
+     * Alle Commit-Zeitpunkte, die eine der Quellen der Seite berührt haben.
+     * Wird in beforeAll erhoben: 35 Seiten mal bis zu zwei Quellen sind rund 50
+     * git-Aufrufe und überschreiten den Standard-Timeout eines Einzeltests.
+     */
+    const commitZeiten = (seite: { sources: string[] }) => {
+        const zeiten = new Set<string>();
+        for (const quelle of seite.sources ?? []) {
+            try {
+                const ausgabe = execFileSync("git", ["log", "--format=%cI", "--", quelle], {
+                    cwd: projekt, encoding: "utf8"
+                });
+                for (const zeile of ausgabe.split("\n")) {
+                    if (zeile.trim() !== "") zeiten.add(zeile.trim());
+                }
+            } catch {
+                // Ohne Git keine Aussage – der Aufrufer prüft das über istFlach().
+            }
+        }
+        return zeiten;
+    };
+
+    /**
+     * Der Wert muss aus der Historie der Seite stammen, nicht aus der Uhr.
+     *
+     * Die frühere Fassung prüfte, ob nicht alle URLs das heutige Datum tragen.
+     * Das war kalenderabhängig und damit unbrauchbar: nach einem Tag, an dem
+     * jede Seite angefasst wurde, tragen zu Recht alle dasselbe Datum, und der
+     * Test schlug an, obwohl der Mechanismus einwandfrei arbeitete. Umgekehrt
+     * wäre er an jedem anderen Tag grün geworden, ohne etwas zu beweisen.
+     *
+     * Diese Fassung ist falsifizierbar und datumsunabhängig: würde lastmod aus
+     * `new Date()` gestempelt, träfe der Wert keinen Commit-Zeitpunkt der Quelle.
+     */
+    it("übernimmt lastmod aus der Historie der Seite, nicht aus der Uhr", () => {
         if (istFlach()) return;
-        const heute = new Date().toISOString().slice(0, 10);
-        const daten = Object.values(werte).map(nurDatum);
-        const alleHeute = daten.length > 0 && daten.every(wert => wert === heute);
-        expect(alleHeute, "jede URL trägt das heutige Datum – riecht nach Build-Datum").toBe(false);
+
+        let geprueft = 0;
+        for (const seite of SITEMAP_PAGES as { slug: string; sources: string[] }[]) {
+            const wert = werte[seite.slug];
+            if (!wert) continue;
+
+            const zeiten = zeitenProSeite[seite.slug] ?? new Set<string>();
+            expect(zeiten.has(wert),
+                `lastmod "${wert}" für "${seite.slug || "/"}" gehört zu keinem Commit `
+                + "ihrer Quellen – stammt der Wert aus der Uhr?").toBe(true);
+            geprueft++;
+        }
+
+        // Ohne geprüfte Seite wäre die Zusicherung wertlos.
+        expect(geprueft, "keine Seite mit lastmod – nichts geprüft").toBeGreaterThan(0);
+    });
+
+    it("nutzt nicht für jede Seite denselben Commit", () => {
+        if (istFlach()) return;
+        // Ergänzt die Datumsprüfung oben um die Streuung: ein einziger Wert für
+        // alle URLs ist das Muster, an dem Google lastmod domainweit entwertet.
+        const werteOhneNull = Object.values(werte).filter(Boolean);
+        expect(new Set(werteOhneNull).size,
+            "alle Seiten tragen denselben Zeitstempel").toBeGreaterThan(1);
     });
 });
 

--- a/tests/seo/Lastmod.test.ts
+++ b/tests/seo/Lastmod.test.ts
@@ -195,16 +195,27 @@ describe("lastmod im echten Repository", () => {
         }
     }, 120_000);
 
-    /** Ist die Quelldatei der Seite überhaupt schon committet? */
-    const istCommittet = (seite: { sources: string[] }) => seite.sources.some(datei => {
+    /**
+     * Ist die Seite selbst schon committet?
+     *
+     * Geprüft wird allein sources[0], die eigene HTML-Quelle. Ein `some` über
+     * alle Quellen wäre falsch: Archivseiten führen zusätzlich ihre
+     * Funkspruch-Datei, und deren Historie kann ausschließlich aus mechanischen
+     * Commits bestehen (nachrichten_thw_saarstedt.txt hat genau einen, mit
+     * Betreff „refactor(…)“). Die Seite gälte dann als committet, obwohl ihr
+     * eigenes HTML noch nirgends steht – und hätte zu Recht kein Datum.
+     */
+    const istCommittet = (seite: { sources: string[] }) => {
+        const eigeneQuelle = seite.sources[0];
+        if (eigeneQuelle === undefined) return false;
         try {
-            return execFileSync("git", ["log", "-1", "--format=%H", "--", datei], {
+            return execFileSync("git", ["log", "-1", "--format=%H", "--", eigeneQuelle], {
                 cwd: projekt, encoding: "utf8"
             }).trim() !== "";
         } catch {
             return false;
         }
-    });
+    };
 
     it("liefert für jede committete Sitemap-Seite ein Datum", () => {
         if (istFlach()) {

--- a/tests/seo/SchemaGraph.test.ts
+++ b/tests/seo/SchemaGraph.test.ts
@@ -7,6 +7,9 @@ import { canonicalUrl, SITE_PAGES, SITE_URL } from "../../scripts/site-pages.mjs
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore -- reine JS-Hilfsmodule ohne Typdeklarationen, absichtlich .mjs
 import { renderPageWithStructuredData, sichtbarerText } from "../../scripts/lib/render-page.mjs";
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+import { BESTAND } from "../../scripts/lib/funkspruch-bestand.mjs";
 
 const ROOT = path.resolve(__dirname, "..", "..");
 // Fester Wert, damit die Erwartungen nicht von der Git-Historie abhängen.
@@ -23,7 +26,12 @@ function graphFuer(page: { source: string }) {
     return renderPageWithStructuredData({
         page,
         html: quelleLesen(page.source),
-        dateModified: DATE_MODIFIED
+        dateModified: DATE_MODIFIED,
+        // Seit AP-08 tragen die Quellseiten Platzhalter für die Bestandszahl
+        // und die Archivseiten ihre Funkspruch-Liste. Ohne Bestand bricht das
+        // Rendern ab – zu Recht, denn eine ausgelieferte Seite mit
+        // unaufgelöstem Platzhalter wäre schlimmer als ein Buildfehler.
+        bestand: BESTAND
     });
 }
 
@@ -87,7 +95,7 @@ function alleSchluessel(wert: unknown, treffer: string[] = []): string[] {
 
 describe("Schema-Graph je Seite", () => {
     it("die Registry deckt alle 30 ausgelieferten URLs ab", () => {
-        expect(SITE_PAGES).toHaveLength(31);
+        expect(SITE_PAGES).toHaveLength(37);
     });
 
     for (const page of SITE_PAGES) {


### PR DESCRIPTION
## Was

Der Bestand unter `assets/funksprueche/` war öffentlich nicht sichtbar. `/funksprueche/`
nannte eine Zahl, zeigte aber keinen einzigen Spruch. Jetzt ist er erschlossen,
durchsuchbar und herunterladbar.

**Der Bestand, gemessen:** 7 Vorlagen, **3.684 Funksprüche, keine einzige Dublette,
3.684 eindeutige IDs**. Davon **2.024 im öffentlichen Archiv** (siehe Entscheidung 2).

| Vorlage | Einträge | Herkunft |
| --- | ---: | --- |
| Grundausbildung, einfache Nachrichten | 462 | organisationsübergreifend |
| THW Lehrte | 752 | THW |
| THW Melle | 400 | THW |
| THW Saarstedt | 200 | THW |
| THW Leer | 118 | THW |
| THW Essen | 92 | THW |
| Humorvolle Lagen | 1.660 | **nicht im Archiv** |

## Zwei Entscheidungen, die vom Paket abweichen

Beide wurden vorab abgestimmt, hier die Messwerte dazu.

### 1. Keine Kategorie-URLs — gegliedert wird nach Vorlage und Herkunft

Das Paket verlangt `/funksprueche/<kategorie>/` und gleichzeitig „Kategorie und
Organisation nach Möglichkeit aus Dateiname und Vorlagenname ableiten, **nicht raten**".
Beides ist mit diesen Daten nicht zugleich erfüllbar:

- Kein Dateiname trägt eine Kategorie. Ableitbar ist nur `organisation: thw`
  (5 Dateien, Muster `nachrichten_thw_*`) und `schwierigkeit: einfach` (1 Datei).
- Mit engen Schlüsselwortregeln auf dem Text landen **1.410 von 2.024 Archiveinträgen
  in „allgemein"** (70 %). Die Nichttreffer sind kurze Betriebsphrasen wie
  „Sind einsatzbereit." — die tragen kein Kategoriemerkmal.
- `Übungsorganisation` käme auf 5 Einträge und wäre nach der eigenen Regel
  („keine Kategorieseite mit weniger als zehn Einträgen") ohnehin keine URL.

Eine Kategorieebene wäre also eine Seite mit 1.410 Einträgen plus fünf Restseiten.
Stattdessen: `/funksprueche/vorlage/<slug>/` je Quelldatei — alles aus dem Dateinamen
belegbar. Das Feld `kategorie` existiert weiter im Datenmodell, wird sichtbar je Eintrag
angezeigt und speist den clientseitigen Filter, trägt aber keine URL.

### 2. Die humorvolle Vorlage bleibt aus dem Archiv

`funksprueche_lustig_kreativ.txt` hat 1.660 Einträge, davon nennen **99 fremde Marken und
Figuren wörtlich**: THOR, MJÖLNIR, MINNIE MAUS, DOBBY, HOGWARTS, POKÉMON, DIGIMON,
SPIDER-MAN und weitere.

Sie im Generator für Übungs-PDFs zu nutzen ist etwas anderes, als sie als indexierbares,
durchsuchbares Archiv mit Download-Button auf der eigenen Domain zu veröffentlichen. Die
Vorlage bleibt im Generator **unverändert wählbar**; `imArchiv: false` nimmt sie nur aus
der Veröffentlichung. Nebeneffekt: keine 1.660 Pokémon-Seiten, die das thematische Profil
für „BOS Sprechfunk Übung" verwässern.

## Vier Fehler, die die Arbeit aufgedeckt hat

1. **`relativerPfad` war für verschachtelte Slugs falsch.** Sie rechnete mit festem
   `"../"`. Eine Seite unter `/funksprueche/vorlage/thw-lehrte/` braucht `"../../../"` —
   jeder Link, jedes Stylesheet und jedes Bild hätte auf einen nicht existierenden Pfad
   gezeigt. Jetzt zählt die Funktion die Slug-Segmente.
2. **Die dokumentierte Zählung lag um eins zu niedrig.** In `CLAUDE.md` stand 3.683 aus
   `cat *.txt | grep -c`. Tatsächlich sind es 3.684: `nachrichten_thw_melle.txt` endet
   ohne Zeilenumbruch, deshalb verklebt `cat` ihre letzte Zeile mit der ersten der
   Folgedatei. Ein Test hält Ursache und Wirkung fest.
3. **Die größte Archivseite lag bei 333 KB** und damit über der 300-KB-Grenze des Pakets.
   Ursache war fettes Listenmarkup: ~266 Byte Rahmen je Eintrag, darunter zwei
   `data`-Attribute, die niemand ausliest, und 16 Zeichen Einrückung. Verschlankt auf
   177 Byte → **268 KB**. Eine neue Regel `zu-viel-markup` prüft die Grenze jetzt, statt
   sie nur zu beobachten. Keine Paginierung nötig.
4. **Die Funkspruch-Liste verfälschte zwei Qualitätsprüfungen.** Als Prosa gelesen ergaben
   462 Meldungen ohne Satzzeichen *einen* Satz mit 124 Wörtern, und ein Funkspruch mit
   „nicht nur" darin wäre ein Floskel-Verstoß gewesen, den man nur durch Fälschen des
   Zitats hätte beheben können. Die Liste ist jetzt aus Lesbarkeits- und Floskelmessung
   ausgenommen, zählt für die Wortzahl aber weiter mit.

Dazu eine Floskel in einer von mir geschriebenen FAQ-Antwort („nicht nur gelegentlich") —
die Denylist hatte recht, der Satz ist umformuliert.

## Abnahmekriterien

- [x] **Alle Funksprüche in der Datenquelle, Anzahl stimmt mit der Zählung der Quelldateien überein** — Vitest zählt je Datei unabhängig vom Prüfling nach; 7/7 Vorlagen, Summe 3.684
- [x] **IDs über zwei Builds stabil** — `baueBestand` zweimal mit gleichem Eingang liefert identische ID-Listen; zusätzlich: ID hängt allein am Text, nicht an Vorlage oder Reihenfolge
- [x] **Jede Seite ≥ 300 Wörter eigener Text und ≥ 10 Einträge** — neue Regel `zu-wenig-eigener-text` misst den Text *neben* der Liste; kleinste Vorlage hat 92 Einträge
- [x] **Playwright mit deaktiviertem JavaScript** — `test.use({ javaScriptEnabled: false })`, je Vorlage die Eintragszahl gegen die Quelldatei plus Stichprobe auf erstem, mittlerem und letztem Spruch im sichtbaren Text
- [x] **Alle neuen URLs in Sitemap und Hub, `CollectionPage`/`ItemList` valide** — 35 Sitemap-URLs, 6 Archivlinks in der Wissens-Seitenleiste; `buildCollection` erweitert um `collectionAnzahl`
- [x] **Keine Seite über 300 KB** — größte 268 KB roh, 58 KB gzip
- [x] **`check-performance-budget.mjs` grün**
- [x] **Download funktioniert und ist als Upload wieder einlesbar** — je Vorlage ein Test, dass die ausgelieferte `.txt` zeichengleich der Quelldatei ist, plus ein Round-Trip: herunterladen, im Generator hochladen, Übung erzeugen, Teilnehmerlinks und Nachrichtenzahl prüfen
- [x] **Die Zahl stammt aus der berechneten Konstante** — Fließtext über Platzhalter, Registry über Template-Literale; ein Test verbietet die Zeichenfolge „1.800" domainweit

### Wo die Prüfung weniger beweist, als sie klingt

Der Round-Trip-Test belegt, dass die Datei gelesen und eine Übung daraus erzeugt wird
(Teilnehmerlinks vorhanden, Nachrichtenzahl ≥ 3 je Funkstelle). Er prüft **nicht** den
Wortlaut der einzelnen verteilten Nachricht: `#jsonOutput` wird nur beim Klick auf
„Kopieren" gefüllt, und es gibt keine andere UI-Fläche, die die verteilten Texte ohne
Firestore zeigt. Nebenbei aufgefallen: **`id="jsonOutput"` existiert doppelt** im DOM der
Startseite, weil das Generator-Markup statisch eingebettet *und* per JS gesetzt wird. Das
ist ein Bestandsproblem, kein Teil dieses PRs.

## Wie zu prüfen

```bash
npm ci && npm run build
node scripts/check-content-quality.mjs
node scripts/check-internal-links.mjs
npm run perf:budget
npx vitest run
npx playwright test
```

Grün: Build, Lint, **1.340** Unit-Tests (54 Dateien), **380** Playwright-Tests,
`links:check` (349 Fließtext-Links, 0 Verstöße), `content:check` (34 Seiten, 0 Verstöße),
`perf:budget`.

Sichtprüfung: `npm run serve`, dann http://127.0.0.1:3000/funksprueche/ — Tabelle mit
Anzahl je Vorlage, von dort in jede Vorlage. Brotkrume folgt der URL
(`Startseite › Funksprüche › Vorlage THW Lehrte`).

## Fachlich zu prüfen

1. **Schreibweise „Saarstedt".** Der Dateiname lautet `nachrichten_thw_saarstedt.txt`,
   der Ort südlich von Hannover heißt **Sarstedt**. Ich habe die Schreibweise der Datei
   übernommen und nicht stillschweigend korrigiert. Wenn es ein Tippfehler ist, sollten
   Dateiname, Vorlagenname und URL zusammen umbenannt werden — dann mit HTML-Stub am
   alten Pfad, weil GitHub Pages keine 301 kann.
2. **Schwierigkeitsstufen aus der Textlänge.** `einfach` bis 80 Zeichen, `schwer` ab 180,
   dazwischen `mittel`. Die Schwellen sind meine Setzung, begründet mit dem
   Mitschreibaufwand (etwa ein Zeichen je Sekunde), nicht mit einer Vorschrift.
3. **Kategoriezuordnung.** Die Regeln sind absichtlich eng gefasst, damit nichts falsch
   einsortiert wird. Ergebnis im Archiv: Sanitätsdienst 171, Unwetter und Hochwasser 116,
   Logistik 69, Stärkemeldung 59, Technische Hilfeleistung 48, Brandeinsatz 47,
   Erkundung 32, Standortmeldung 30, Materialanforderung 24, Personalmeldung 13,
   Übungsorganisation 5, **allgemein 1.410**. Wer die 1.410 redaktionell zuordnen will,
   hat damit die Grundlage.
4. **Vorlagenbeschreibungen.** Die sechs Einleitungstexte beschreiben Lage und Zweck aus
   dem, was ich in den Dateien gelesen habe (Ortsnamen, Meldearten, Textlängen). Ob die
   Vorlagen tatsächlich so entstanden sind und ob die Zuordnung zu Ausbildungsständen
   (Grundausbildung / Führungskräfte) fachlich trägt, kann ich nicht belegen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
