### PR TITLE
seo(AP-09): Vergleichs- und Alternative-Seiten mit Belegpflicht

### DIFF
--- a/scripts/check-internal-links.mjs
+++ b/scripts/check-internal-links.mjs
@@ -12,7 +12,7 @@ import { readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { SITE_PAGES } from "./site-pages.mjs";
+import { HUB_SLUG, SITE_PAGES } from "./site-pages.mjs";
 import { ankerHinweise, baueBericht, pruefeRegeln } from "./lib/internal-links.mjs";
 import { plainText } from "./lib/page-metadata.mjs";
 
@@ -76,6 +76,9 @@ async function main() {
         // einschließlich der generierten Blöcke – es geht um die Seitenlast.
         seite.linksImMain = [...mainBereich.matchAll(/<a[^>]+href="([^"]*)"/gi)]
             .filter(treffer => slugAusHref(treffer[1]) !== null).length;
+        // Der Hub ist von der Obergrenze ausgenommen: seine Kartenliste ist der
+        // Seiteninhalt und wächst mit jeder neuen Seite (siehe lib/internal-links.mjs).
+        seite.istHub = seite.slug === HUB_SLUG;
 
         for (const treffer of fliesstext.matchAll(/<a[^>]+href="([^"]*)"[^>]*>([\s\S]*?)<\/a>/gi)) {
             const ziel = slugAusHref(treffer[1]);

--- a/scripts/lib/internal-links.mjs
+++ b/scripts/lib/internal-links.mjs
@@ -101,7 +101,14 @@ export function pruefeRegeln(seiten, links, grenzwerte = GRENZWERTE) {
         }
 
         // 4. Zu viele interne Links im main-Bereich.
-        if (seite.linksImMain !== undefined && seite.linksImMain > grenzwerte.maxLinksProSeite) {
+        //
+        // Der Hub ist ausgenommen. Die Regel soll verhindern, dass redaktionelle
+        // Seiten mit Links zugestopft werden; der Inhalt des Hubs *ist* die
+        // Linkliste, und sie wächst mit jeder neuen Seite. Bei 37 Seiten lag er
+        // bei 42 Links – die Grenze wäre dort dauerhaft und ohne Erkenntnisgewinn
+        // verletzt, während sie für jede andere Seite ihren Zweck behält.
+        if (!seite.istHub && seite.linksImMain !== undefined
+            && seite.linksImMain > grenzwerte.maxLinksProSeite) {
             verstoesse.push({
                 regel: "zu-viele-links",
                 seite: seite.slug,

--- a/scripts/site-pages.mjs
+++ b/scripts/site-pages.mjs
@@ -989,6 +989,64 @@ export const SITE_PAGES = [
         ]
     },
     {
+        slug: "kostenlos-ohne-anmeldung", source: "pages/kostenlos-ohne-anmeldung.html", sources: ["src/pages/kostenlos-ohne-anmeldung.html"],
+        kurzGesagt: "Die Nutzung ist kostenlos und verlangt kein Konto, keine Zahlungsdaten und keine Installation. Es gibt keine Testphase, die abläuft, und keine Funktion hinter einer Bezahlschranke. Gespeichert werden nur die Angaben, die für die Übung eingetragen werden, und die sind für jeden lesbar, der den Link kennt. Der Quellcode steht unter der EUPL-1.2 auf GitHub.",
+        related: ["open-source","faq","funktionen"],
+        label: "Kostenlos und ohne Anmeldung",
+        hubCategory: "anwendung",
+        schemaType: "Article", datePublished: "2026-08-04",
+        about: ["Funkübung", "Kostenlos und ohne Anmeldung"],
+        faq: [
+            {
+                q: "Gibt es eine Bezahlversion?",
+                a: "Nein. Es gibt keine Preisstufen, keine Premium-Funktionen und keine Obergrenzen für Teilnehmer, Übungen oder Exporte. Alle Funktionen sind vollständig verfügbar."
+            },
+            {
+                q: "Muss ich mich registrieren?",
+                a: "Nein. Es gibt kein Benutzerkonto und keine Anmeldung. Die Anwendung kennt keinen Begriff von Identität – Übungsleitung, Teilnehmer und Verwaltung sind reine Ansichten im Browser."
+            },
+            {
+                q: "Werden meine Übungsdaten gespeichert?",
+                a: "Ja. Übungsname, Funkrufnamen und die erzeugten Funksprüche liegen bei Firebase, dazu der Fortschritt je Funkstelle. Weil es keine Anmeldung gibt, gibt es auch keinen Zugriffsschutz: wer den Link hat, kann die Übung öffnen."
+            },
+            {
+                q: "Kann ich die Anwendung offline nutzen?",
+                a: "Nur eingeschränkt. Zum Erzeugen einer Übung und für den Teilnehmerzugang wird eine Verbindung gebraucht. Die Druckunterlagen lassen sich vorher als PDF oder ZIP herunterladen und offline verwenden."
+            },
+            {
+                q: "Darf ich sie in meiner Dienststelle einsetzen?",
+                a: "Die EUPL-1.2 erlaubt das, auch dienstlich. Ob die eigene Organisation den Einsatz eines externen Webdienstes zulässt, ist davon unabhängig zu klären – die Übungsdaten liegen bei Firebase."
+            }
+        ]
+    },
+    {
+        slug: "alternative", source: "pages/alternative.html", sources: ["src/pages/alternative.html"],
+        kurzGesagt: "Eine Sprechfunkübung lässt sich auf vier Wegen vorbereiten: von Hand, mit einer Tabellenvorlage, mit einem freien Generator oder mit einer kommerziellen Web-Anwendung. Die Wege unterscheiden sich in Vorbereitungszeit, Kosten, Registrierung und Funktionsumfang. Diese Seite stellt die Merkmale gegenüber, statt einen Sieger zu benennen. Für zwei Bedarfe ist die kommerzielle Lösung die passendere Wahl.",
+        related: ["funkuebung-planen","funkuebung-vorlage","kostenlos-ohne-anmeldung"],
+        label: "Alternativen im Vergleich",
+        hubCategory: "uebungen",
+        schemaType: "Article", datePublished: "2026-08-04",
+        about: ["Funkübung", "Alternativen im Vergleich"],
+        faq: [
+            {
+                q: "Was ist die Alternative zu einem Funkübungs-Generator mit Konto?",
+                a: "Drei Wege ohne Konto: von Hand mit Vordrucken, eine Excel- oder Word-Vorlage aus der eigenen Einheit, oder ein freier Generator im Browser. Welcher passt, hängt von Teilnehmerzahl, Zeit und den Vorgaben der Organisation ab."
+            },
+            {
+                q: "Wodurch unterscheiden sich die Angebote am deutlichsten?",
+                a: "An der Registrierung, an Mengengrenzen und an der Quelloffenheit. Bei den Kernfunktionen – Verteilung, PDF, Teilnehmerzugang, Live-Übungsleitung – liegen die Web-Anwendungen näher beieinander, als es zunächst wirkt."
+            },
+            {
+                q: "Wann ist eine kostenpflichtige Lösung die richtige?",
+                a: "Wenn über Rechnung beschafft werden muss, wenn ein Vertragspartner mit Zuständigkeit gebraucht wird oder wenn mehrere Personen mit eigenen Zugängen an Übungen arbeiten sollen. Ohne Benutzerkonten gibt es keine Rechteverwaltung."
+            },
+            {
+                q: "Sind die Angaben über andere Anbieter aktuell?",
+                a: "Sie stammen von der öffentlichen Website des jeweiligen Anbieters und tragen im Quelltext dieser Seite Fundstelle und Abrufdatum. Die Angaben werden halbjährlich geprüft; maßgeblich bleibt immer die Website des Anbieters."
+            }
+        ]
+    },
+    {
         slug: "wissen", source: "pages/wissen.html", sources: ["src/pages/wissen.html"],
         kurzGesagt: "Sprechfunk lernt man im Lehrgang und behält es durch regelmäßiges Üben. Diese Übersicht bündelt beides: die fachlichen Grundlagen des BOS-Sprechfunks und die praktische Arbeit mit Funkübungen. Die Betriebsabwicklung folgt organisationsübergreifend der PDV/DV 810.3. Für die Praxis erzeugt der Generator vollständige Übungen.",
         related: ["funkuebung-planen", "sprechfunk-regeln", "funksprueche"],

--- a/seo/content-quality-report.md
+++ b/seo/content-quality-report.md
@@ -11,26 +11,28 @@ Inhaltsverzeichnis, Metazeile, Seitenleiste und Weiterlesen-Block sind abgezogen
 
 | Seite | Wörter | Ziel | Titel | Desc | gzip |
 | --- | ---: | ---: | ---: | ---: | ---: |
-| `/funkuebung-planen/` | 822 | 800 | 53 | 149 | 8 KB |
-| `/open-source/` | 825 | 800 | 53 | 150 | 8 KB |
 | `/digitale-funkuebung/` | 826 | 800 | 51 | 152 | 7 KB |
 | `/meldevordruck/` | 831 | 800 | 51 | 150 | 7 KB |
 | `/funkrufnamen-thw/` | 832 | 800 | 51 | 149 | 8 KB |
 | `/funkrufnamen/` | 846 | 800 | 55 | 155 | 8 KB |
 | `/wissen/` | 847 | 800 | 53 | 155 | 10 KB |
 | `/faq/` | 854 | 800 | 53 | 149 | 8 KB |
-| `/funktionen/` | 861 | 800 | 53 | 153 | 8 KB |
 | `/verkehrsarten/` | 872 | 800 | 55 | 152 | 8 KB |
-| `/funkuebung-vorlage/` | 882 | 800 | 52 | 150 | 8 KB |
 | `/funkuebung-katastrophenschutz/` | 884 | 800 | 50 | 149 | 8 KB |
+| `/funkuebung-planen/` | 891 | 800 | 53 | 149 | 8 KB |
+| `/open-source/` | 920 | 800 | 53 | 150 | 8 KB |
 | `/funksprueche/` | 930 | 800 | 53 | 154 | 8 KB |
+| `/kostenlos-ohne-anmeldung/` | 945 | 800 | 54 | 156 | 7 KB |
 | `/betriebsworte/` | 949 | 800 | 56 | 155 | 9 KB |
 | `/funkmeldesystem/` | 953 | 800 | 52 | 150 | 8 KB |
+| `/funktionen/` | 963 | 800 | 53 | 153 | 8 KB |
+| `/funkuebung-vorlage/` | 972 | 800 | 52 | 150 | 8 KB |
 | `/funkuebung-dienstabend/` | 984 | 900 | 52 | 153 | 8 KB |
-| `/antennen/` | 990 | 800 | 55 | 155 | 8 KB |
+| `/antennen/` | 990 | 800 | 55 | 155 | 9 KB |
 | `/bos-funk/` | 1057 | 800 | 51 | 153 | 9 KB |
 | `/funkuebung-thw/` | 1094 | 1000 | 52 | 156 | 9 KB |
 | `/funkreichweite/` | 1097 | 800 | 51 | 156 | 9 KB |
+| `/alternative/` | 1120 | 800 | 56 | 149 | 8 KB |
 | `/funkuebung-feuerwehr/` | 1135 | 1100 | 51 | 156 | 9 KB |
 | `/uebungsfunkverkehr/` | 1155 | 800 | 52 | 155 | 9 KB |
 | `/x-zeit/` | 1170 | 800 | 53 | 153 | 8 KB |

--- a/seo/internal-links-report.md
+++ b/seo/internal-links-report.md
@@ -11,9 +11,9 @@ auf jeder Seite gleich sind.
 
 ## Überblick
 
-- Seiten in der Registry: 37
-- davon Inhaltsseiten: 34
-- Fließtext-Links gesamt: 349
+- Seiten in der Registry: 39
+- davon Inhaltsseiten: 36
+- Fließtext-Links gesamt: 369
 - Verstöße: 0
 - Seiten ohne eingehenden Fließtext-Link: 0
 
@@ -25,33 +25,35 @@ Keine. Jede Inhaltsseite hat mindestens einen eingehenden Fließtext-Link.
 
 | Seite | eingehend | ausgehend |
 | --- | ---: | ---: |
-| `/meldevordruck/` | 29 | 5 |
+| `/meldevordruck/` | 30 | 5 |
+| `/funksprueche/` | 26 | 10 |
 | `/buchstabiertafel/` | 25 | 7 |
 | `/regiebuch-funkuebung/` | 25 | 9 |
-| `/funksprueche/` | 23 | 10 |
+| `/anleitung/` | 18 | 13 |
 | `/sprechfunk-regeln/` | 18 | 19 |
-| `/anleitung/` | 16 | 13 |
-| `/funkuebung-planen/` | 14 | 17 |
+| `/funkuebung-planen/` | 14 | 19 |
 | `/bos-funk/` | 13 | 13 |
-| `/open-source/` | 13 | 6 |
+| `/open-source/` | 13 | 8 |
 | `/funkuebung-dienstabend/` | 12 | 12 |
 | `/digitale-funkuebung/` | 11 | 7 |
-| `/funkrufnamen/` | 9 | 13 |
+| `/funkrufnamen/` | 10 | 13 |
 | `/funkuebung-thw/` | 8 | 15 |
 | `/betriebsworte/` | 8 | 12 |
 | `/funkuebung-feuerwehr/` | 7 | 8 |
-| `/funkuebung-vorlage/` | 7 | 14 |
+| `/funkuebung-vorlage/` | 7 | 16 |
 | `/funkuebung-szenarien/` | 7 | 17 |
 | `/uebungsfunkverkehr/` | 6 | 12 |
 | `/funkreichweite/` | 6 | 14 |
 | `/x-zeit/` | 5 | 8 |
+| `/kostenlos-ohne-anmeldung/` | 5 | 6 |
 | `/funksprueche/vorlage/thw-lehrte/` | 4 | 3 |
 | `/funksprueche/vorlage/thw-melle/` | 4 | 2 |
 | `/funkuebung-katastrophenschutz/` | 4 | 10 |
 | `/verkehrsarten/` | 4 | 12 |
 | `/antennen/` | 4 | 7 |
+| `/alternative/` | 4 | 6 |
 | `/faq/` | 4 | 11 |
-| `/funktionen/` | 3 | 21 |
+| `/funktionen/` | 3 | 23 |
 | `/funksprueche/vorlage/grundausbildung-einfach/` | 3 | 3 |
 | `/funksprueche/vorlage/thw-essen/` | 3 | 2 |
 | `/funksprueche/vorlage/thw-leer/` | 3 | 2 |
@@ -65,17 +67,17 @@ Keine. Jede Inhaltsseite hat mindestens einen eingehenden Fließtext-Link.
 | Ziel | Varianten | Ankertexte |
 | --- | ---: | --- |
 | `/meldevordruck/` | 8 | „druckvordrucke“, „lagemeldung“, „meldevordruck“, „meldevordruck und nachrichtenvordruck“, „meldevordrucke“, „nachrichtenvordruck“, „pdf-vordrucken“, „vordrucke“ |
+| `/funksprueche/` | 12 | „3.684 funksprüche“, „3.684 funksprüchen“, „beispiel-funksprüche ansehen“, „fertige funksprüche“, „funkspruch-archiv“, „funkspruch-vorlagen“, „funksprüche“, „funksprüche ansehen“, „funksprüche für übungen“, „funksprüchen“, „vorlagen“, „übungspool“ |
 | `/buchstabiertafel/` | 4 | „buchstabieren“, „buchstabiertafel“, „buchstabiertafel inland“, „zahlentafel“ |
 | `/regiebuch-funkuebung/` | 11 | „auswertung“, „live-cockpit“, „live-nachrichtenplan“, „live-übungsleitung“, „live-übungsleitung ansehen“, „nachrichtenplan“, „nachrichtenplan ansehen“, „regiebuch“, „regiebuch der übung“, „regiebuch mit live-übungsleitung“, „übungsleitung“ |
-| `/funksprueche/` | 11 | „3.684 funksprüche“, „3.684 funksprüchen“, „beispiel-funksprüche ansehen“, „fertige funksprüche“, „funkspruch-vorlagen“, „funksprüche“, „funksprüche ansehen“, „funksprüche für übungen“, „funksprüchen“, „vorlagen“, „übungspool“ |
-| `/sprechfunk-regeln/` | 6 | „anrufverfahren“, „funkdisziplin“, „sprechfunk-regeln“, „sprechfunk-regeln im bos-funk“, „sprechfunkregeln“, „sprechfunkverkehr“ |
 | `/anleitung/` | 4 | „anleitung“, „schritt-für-schritt-anleitung“, „sprechfunkübung“, „zur anleitung“ |
+| `/sprechfunk-regeln/` | 6 | „anrufverfahren“, „funkdisziplin“, „sprechfunk-regeln“, „sprechfunk-regeln im bos-funk“, „sprechfunkregeln“, „sprechfunkverkehr“ |
 | `/funkuebung-planen/` | 8 | „funkübung“, „funkübung planen“, „geplanten funkübung“, „planen“, „planung einer funkübung“, „schritt-für-schritt-planung“, „übung“, „übungsplanung“ |
 | `/bos-funk/` | 5 | „bos-funk grundlagen“, „bos-funk-grundlagen zu digitalfunk und tetra“, „digitalfunk“, „digitalfunk bos“, „rufgruppen im thw“ |
 | `/open-source/` | 2 | „kostenlos, ohne anmeldung, quelloffen“, „kostenlos, quelloffen (eupl-1.2) und datensparsam“ |
 | `/funkuebung-dienstabend/` | 4 | „ablauf für den dienstabend“, „dienstabend“, „funkübung am dienstabend“, „funkübung für den dienstabend“ |
 | `/digitale-funkuebung/` | 5 | „digital am smartphone“, „digitale funkübung“, „digitale funkübung per smartphone“, „digitalen funkübung“, „teilnehmeransicht“ |
-| `/funkrufnamen/` | 4 | „funkrufnamen“, „funkrufnamen im bos-funk“, „funkrufnamen verstehen“, „funkrufnamens“ |
+| `/funkrufnamen/` | 5 | „funkrufname“, „funkrufnamen“, „funkrufnamen im bos-funk“, „funkrufnamen verstehen“, „funkrufnamens“ |
 | `/funkuebung-thw/` | 4 | „funkübung im thw“, „funkübung thw“, „thw“, „thw-ortsverbände“ |
 | `/betriebsworte/` | 4 | „betriebsworte“, „betriebsworte im bos-funk“, „kommen“, „„ich buchstabiere““ |
 | `/funkuebung-feuerwehr/` | 2 | „feuerwehr“, „funkübung feuerwehr“ |
@@ -84,11 +86,13 @@ Keine. Jede Inhaltsseite hat mindestens einen eingehenden Fließtext-Link.
 | `/uebungsfunkverkehr/` | 2 | „blitz- und staatsnot-nachrichten“, „übungsfunkverkehr“ |
 | `/funkreichweite/` | 3 | „merkregeln zur störungsbeseitigung“, „reichweite“, „reichweite von funkwellen“ |
 | `/x-zeit/` | 4 | „der x-zeit-modus“, „fälligkeitszeitpunkt als x+n“, „x-zeit“, „zeitversetzte fälligkeiten“ |
+| `/kostenlos-ohne-anmeldung/` | 2 | „funkübung kostenlos und ohne anmeldung“, „kostenlos und ohne anmeldung“ |
 | `/funksprueche/vorlage/thw-lehrte/` | 4 | „752 nachrichten aus lehrte“, „große unwetterlage aus lehrte“, „thw lehrte“, „unwetterlage aus lehrte“ |
 | `/funksprueche/vorlage/thw-melle/` | 4 | „400 nachrichten aus melle“, „fachdichte lage aus melle“, „thw melle“, „vorlage aus melle“ |
 | `/funkuebung-katastrophenschutz/` | 4 | „funkübung im katastrophenschutz“, „hilfsorganisationen“, „katastrophenschutz“, „mehrere organisationen“ |
 | `/verkehrsarten/` | 2 | „verkehrsarten“, „verkehrsarten und relaisbetrieb“ |
 | `/antennen/` | 3 | „antennen“, „antennen und antennenleitungen“, „art der antenne“ |
+| `/alternative/` | 4 | „den wegen zur sprechfunkübung im vergleich“, „der vergleich der vier wege“, „die vier wege im vergleich“, „eine gegenüberstellung der vier gängigen wege“ |
 | `/faq/` | 2 | „faq“, „häufige fragen“ |
 | `/funktionen/` | 3 | „alle funktionen im überblick“, „bausteinen der anwendung“, „überblick über die funktionen“ |
 | `/funksprueche/vorlage/grundausbildung-einfach/` | 3 | „grundausbildung, einfache nachrichten“, „sammlung kurzer meldungen aus der grundausbildung“, „vorlage für die grundausbildung“ |
@@ -106,5 +110,6 @@ Keine. Jede Inhaltsseite hat mindestens einen eingehenden Fließtext-Link.
 - `/verkehrsarten/`: nur 2 verschiedene Ankertexte (Ziel: 3)
 - `/funkrufnamen-thw/`: nur 1 verschiedene Ankertexte (Ziel: 3)
 - `/open-source/`: nur 2 verschiedene Ankertexte (Ziel: 3)
+- `/kostenlos-ohne-anmeldung/`: nur 2 verschiedene Ankertexte (Ziel: 3)
 - `/faq/`: nur 2 verschiedene Ankertexte (Ziel: 3)
 

--- a/seo/wettbewerbsvergleich.md
+++ b/seo/wettbewerbsvergleich.md
@@ -1,0 +1,71 @@
+# Wettbewerbsvergleich: Quellen und Belege
+
+Register aller Aussagen über Dritte, die auf sprechfunk-uebung.de veröffentlicht sind
+(AP-09). **Von Hand gepflegt** – im Gegensatz zu den übrigen Dateien unter `seo/` wird
+diese nicht generiert.
+
+Regeln:
+
+1. Jede Aussage über einen Dritten braucht hier eine Zeile mit Quelle und Abrufdatum.
+2. Steht eine Aussage nicht hier, darf sie nicht auf der Website stehen.
+3. Nur Merkmale, die auf der öffentlichen Website des Anbieters nachlesbar sind. Keine
+   Wertung, keine Rückschlüsse, keine Angaben aus zweiter Hand.
+4. Wiedervorlage alle sechs Monate. Ändert sich eine Angabe, wird zuerst die Website
+   korrigiert, dann diese Datei.
+
+**Letzte Erhebung: 2026-08-04** · **Nächste Wiedervorlage: 2027-02-04**
+
+## Status der Prüfung
+
+| Schritt | Wer | Stand |
+| --- | --- | --- |
+| Erhebung von der Anbieter-Website | Claude Code (automatisiert, WebFetch) | 2026-08-04 |
+| Fachliche Bestätigung | Johannes Rudolph | **offen** |
+| Rechtliche Freigabe (§ 6 UWG) | Johannes Rudolph | **offen** |
+
+Solange die letzten beiden Zeilen offen sind, darf `/alternative/` nicht nach main
+gemergt werden.
+
+## funkuebung.de
+
+Verwendet auf: `/alternative/` (Abschnitte „Weg 4", „Die Merkmale nebeneinander",
+„Wann die kommerzielle Lösung die bessere Wahl ist").
+
+| Nr. | Aussage auf unserer Seite | Quelle | Abgerufen | Belegtext von dort |
+| --- | --- | --- | --- | --- |
+| 1 | Nennt für den Einstieg eine Registrierung mit E-Mail-Adresse | https://funkuebung.de/ | 2026-08-04 | „Registrierung mit E-Mail" |
+| 2 | Dauerhaft kostenloser Tarif mit Mengengrenzen | https://funkuebung.de/preise | 2026-08-04 | Tarif „Dienstabend", u. a. „Bis zu 8 Teilnehmer pro Übung", „30 KI-Meldungen pro Monat", „4 PDF-Exporte pro Jahr" |
+| 3 | Zwei kostenpflichtige Tarife, monatlich kündbar | https://funkuebung.de/preise | 2026-08-04 | „Einheit" 9,00 € monatlich, „Ausbildung" 29,00 € monatlich; „Monatlich kündbar, ohne lange Vertragsbindung" |
+| 4 | Meldungen werden per KI erzeugt | https://funkuebung.de/ | 2026-08-04 | „KI-Meldungen auf Knopfdruck" |
+| 5 | PDF-Übungsdokument vorhanden | https://funkuebung.de/ | 2026-08-04 | „PDF-Übungsdokument" |
+| 6 | Digitaler Teilnehmerzugang per Code | https://funkuebung.de/ | 2026-08-04 | „Digitaler Teilnehmerzugang per Code" |
+| 7 | Live-Cockpit für die Übungsleitung | https://funkuebung.de/ | 2026-08-04 | „Live-Cockpit" |
+| 8 | Team-Arbeit mit mehreren Logins je Organisation | https://funkuebung.de/ | 2026-08-04 | „Im Team arbeiten – Teilt Übungen innerhalb eurer Einheit … mit mehreren Logins für die Organisation" |
+| 9 | Beschaffung über Rechnung möglich | https://funkuebung.de/preise | 2026-08-04 | „Behörden, Ausbildungsstätten & Verbände: Die Beschaffung über Rechnung ist möglich, ohne private Zahlungsmittel." |
+| 10 | Grenze von acht Teilnehmern im kostenlosen Tarif | https://funkuebung.de/preise | 2026-08-04 | „Bis zu 8 Teilnehmer pro Übung" |
+
+### Bewusst nicht behauptet
+
+Diese Punkte stehen **nicht** auf der Website, weil kein Beleg vorliegt:
+
+| Nicht behauptet | Grund |
+| --- | --- |
+| Konkrete Beträge auf `/alternative/` | Preise können sich ändern; ein veralteter Betrag wäre irreführend. Die Seite nennt nur die Tarifstruktur mit Abrufdatum und verlinkt die Preisseite. |
+| Wie der Anbieter mit Daten umgeht | Nicht geprüft. Die Vergleichstabelle verweist auf dessen Datenschutzerklärung, statt eine Aussage zu treffen. |
+| Ob es einen Gastzugang ohne Konto gibt | Nicht auffindbar. `https://funkuebung.de/registrieren` lieferte am 2026-08-04 HTTP 404; geraten wird nicht. |
+| Anzahl verfügbarer Meldungen | Wird nicht als Zahl ausgewiesen. Die Tabelle sagt genau das. |
+| Quelloffenheit des Anbieters | Auf der Website nicht ausgewiesen. Die Tabelle sagt „nicht ausgewiesen", nicht „nein". |
+
+## Aussagen über die eigene Anwendung
+
+Nicht Gegenstand von § 6 UWG, aber ebenfalls belegpflichtig – sie müssen mit
+`/datenschutz/` und dem Code übereinstimmen.
+
+| Aussage | Beleg im Repo |
+| --- | --- |
+| Kein Konto, keine Anmeldung | `firestore.rules`, Kopfkommentar: „Die Anwendung kennt keine Authentifizierung." |
+| Kein Zugriffsschutz auf Übungen | `firestore.rules`, Restrisiko 1: „Jeder mit dem öffentlichen API-Key kann Übungen lesen, anlegen und LÖSCHEN. Der Übungscode ist ein Auffindbarkeits-, kein Zugriffsschutz." |
+| Gespeichert werden Übungsname, Funkrufnamen, Funksprüche | `src/pages/datenschutz.html`, Abschnitt 4 (Firebase) |
+| Keine Werbe-Cookies, anonyme Reichweitenmessung | `src/pages/datenschutz.html`, Abschnitt 3 (GoatCounter) |
+| EUPL-1.2, Quellcode öffentlich | `LICENSE`, `README.md` |
+| Keine Speicherdauer zugesagt | `firestore.rules` enthält keine TTL, es gibt keinen Aufräumjob. Die Seiten nennen deshalb **keine** Dauer. |

--- a/src/pages/alternative.html
+++ b/src/pages/alternative.html
@@ -1,0 +1,232 @@
+<!DOCTYPE html>
+<html lang="de">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Vier Alternativen zur Vorbereitung einer Sprechfunkübung</title>
+    <link rel="icon" type="image/png" href="../assets/favicon.png">
+    <link rel="canonical" href="https://sprechfunk-uebung.de/alternative/">
+    <meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1">
+    <meta name="theme-color" content="#0d6efd">
+
+    <meta name="description" content="Handarbeit, Excel-Vorlage, freier Generator oder kommerzielle Web-Anwendung: die Wege im sachlichen Vergleich, mit den Punkten, an denen jeder passt.">
+    <meta name="author" content="Johannes Rudolph">
+
+    <meta property="og:title" content="Vier Alternativen zur Vorbereitung einer Sprechfunkübung">
+    <meta property="og:description" content="Handarbeit, Excel-Vorlage, freier Generator oder kommerzielle Web-Anwendung: die Wege im sachlichen Vergleich, mit den Punkten, an denen jeder passt.">
+    <meta property="og:url" content="https://sprechfunk-uebung.de/alternative/">
+    <meta property="og:type" content="article">
+    <meta property="og:locale" content="de_DE">
+    <meta property="og:site_name" content="Sprechfunk Übungsgenerator">
+    <meta property="og:image" content="https://sprechfunk-uebung.de/assets/og-image.png">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">
+    <meta property="og:image:alt" content="Sprechfunk Übungsgenerator – Übungen für den BOS-Sprechfunk erstellen">
+
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Vier Alternativen zur Vorbereitung einer Sprechfunkübung">
+    <meta name="twitter:description" content="Handarbeit, Excel-Vorlage, freier Generator oder kommerzielle Web-Anwendung: die Wege im sachlichen Vergleich, mit den Punkten, an denen jeder passt.">
+    <meta name="twitter:image" content="https://sprechfunk-uebung.de/assets/og-image.png">
+
+    <link rel="stylesheet" href="../bundle.css">
+    <link rel="stylesheet" href="../style.css">
+
+    <!-- GoatCounter: cookielose, anonyme Reichweitenmessung -->
+    <script data-goatcounter="https://sprechfunk-uebung.goatcounter.com/count"
+            async src="//gc.zgo.at/count.js"></script>
+
+    <script>
+        // Gleiche Theme-Auswahl wie in der App anwenden (statische Seiten laden kein Bundle).
+        document.addEventListener("DOMContentLoaded", function () {
+            var stored = localStorage.getItem("theme");
+            if (stored) {
+                document.body.setAttribute("data-theme", stored);
+            }
+        });
+    </script>
+</head>
+
+<body data-theme="light">
+<header class="app-header">
+    <div class="container app-header-grid">
+        <div class="app-header-title">
+            <p class="h2 mb-0">
+                <i class="fas fa-broadcast-tower"></i> Sprechfunk Übungsgenerator
+            </p>
+        </div>
+        <div class="app-header-actions d-none d-md-flex">
+            <a href="../" class="btn btn-primary">
+                <i class="fas fa-arrow-left"></i> Zur Anwendung
+            </a>
+            <a href="../anleitung/" class="btn btn-info">
+                <i class="fas fa-book"></i> Anleitung
+            </a>
+            <a href="https://github.com/wattnpapa/sprechfunk-uebung" class="btn btn-dark">
+                <i class="fab fa-github"></i> GitHub
+            </a>
+        </div>
+    </div>
+</header>
+
+<main class="container my-4 app-view-shell">
+    <nav aria-label="Brotkrumennavigation" class="mb-3">
+        <ol class="breadcrumb mb-0">
+            <li class="breadcrumb-item"><a href="../">Startseite</a></li>
+            <li class="breadcrumb-item active" aria-current="page">Alternativen im Vergleich</li>
+        </ol>
+    </nav>
+
+    <article>
+        <div class="card mb-3">
+            <div class="card-body">
+                <h1 class="h3">Wege zur Sprechfunkübung im Vergleich</h1>
+                <p class="mb-0">
+                    Wer eine <strong>Sprechfunkübung</strong> vorbereitet, hat vier Wege. Diese
+                    Seite stellt sie nach denselben Merkmalen gegenüber und benennt für jeden,
+                    wann er passt. Bewerten sollst du selbst; die Angaben sind so gewählt, dass
+                    sie nachprüfbar sind.
+                </p>
+            </div>
+        </div>
+
+        <section class="card shadow-sm mb-4">
+            <div class="card-header"><h2 class="h4 mb-0" id="handarbeit">Weg 1: von Hand mit Zettel und Vordruck</h2></div>
+            <div class="card-body">
+                <p>Die Übungsleitung schreibt die Nachrichten selbst, verteilt sie auf die Funkstellen und führt die Liste auf Papier. Nötig sind ein Stift, leere <a href="../meldevordruck/">Vordrucke</a> und Zeit.</p>
+                <p>Der Aufwand liegt in der Verteilung, nicht im Schreiben. Bei zehn Funkstellen mit je acht Nachrichten sind das achtzig Zeilen, die zu jeder Funkstelle passen müssen – und jede Änderung an der Teilnehmerliste macht die halbe Arbeit zunichte.</p>
+                <p class="mb-0">Dafür braucht es keine Technik, keinen Anbieter und keine Verbindung. Für eine kleine Übung mit drei Funkstellen ist das der schnellste Weg überhaupt.</p>
+            </div>
+        </section>
+
+        <section class="card shadow-sm mb-4">
+            <div class="card-header"><h2 class="h4 mb-0" id="tabelle">Weg 2: Excel- oder Word-Vorlage</h2></div>
+            <div class="card-body">
+                <p>Der verbreitetste Weg in der Praxis: eine Tabelle, die im Ortsverband weitergegeben wird. Sie nimmt die Verteilungsarbeit ab, wenn jemand die Formeln gebaut hat.</p>
+                <p>Zwei Grenzen sind typisch. Erstens die Wiederholung: die Texte in der Datei sind endlich, und nach dem dritten Einsatz kennt die Einheit sie. Zweitens die Ausgabe – aus einer Tabelle wird kein befüllter Nachrichtenvordruck, ohne dass jemand ihn baut.</p>
+                <p class="mb-0">Für Einheiten mit einer gepflegten Vorlage und wechselnden eigenen Texten ist das ein solider Weg, der niemandem Rechenschaft schuldet.</p>
+            </div>
+        </section>
+
+        <section class="card shadow-sm mb-4">
+            <div class="card-header"><h2 class="h4 mb-0" id="freier-generator">Weg 3: dieser Generator</h2></div>
+            <div class="card-body">
+                <p>Teilnehmer eintragen, Umfang festlegen, Vorlage wählen – Verteilung, Druckunterlagen und Teilnehmerlinks entstehen daraus. Der Bestand liegt offen im <a href="../funksprueche/">Funkspruch-Archiv</a> und ist vor der Übung einsehbar.</p>
+                <p>Kein Konto, keine Installation, keine Obergrenzen. Der Quellcode steht unter der EUPL-1.2, die Anwendung lässt sich selbst betreiben. Was das im Einzelnen bedeutet, steht unter <a href="../kostenlos-ohne-anmeldung/">kostenlos und ohne Anmeldung</a>.</p>
+                <p class="mb-0">Die Kehrseite steht dort ebenfalls: ohne Konto gibt es keinen Zugriffsschutz und keine Rechteverwaltung. Es gibt außerdem keinen Anbieter, keinen Vertrag und keinen Anspruch auf Unterstützung.</p>
+            </div>
+        </section>
+
+        <section class="card shadow-sm mb-4">
+            <div class="card-header"><h2 class="h4 mb-0" id="kommerziell">Weg 4: kommerzielle Web-Anwendung mit Konto</h2></div>
+            <div class="card-body">
+                <p>Im deutschsprachigen Raum ist <a href="https://funkuebung.de/" target="_blank" rel="noopener noreferrer">funkuebung.de</a> das bekannteste Angebot dieser Art. Die folgenden Angaben stammen von der öffentlichen Website des Anbieters, abgerufen am 4. August 2026; im Quelltext dieser Seite steht je Aussage die Fundstelle.</p>
+                <p>Die Website nennt für den Einstieg eine Registrierung mit E-Mail-Adresse und beschreibt drei Tarife: einen dauerhaft kostenlosen mit Mengengrenzen sowie zwei kostenpflichtige, monatlich kündbare. Beträge stehen hier bewusst nicht – sie können sich ändern; die aktuellen nennt die Preisseite des Anbieters.</p>
+                <p class="mb-0">Als Leistungen führt die Website unter anderem per KI erzeugte Meldungen, ein PDF-Übungsdokument, einen digitalen Teilnehmerzugang per Code, ein Live-Cockpit für die Übungsleitung sowie Team-Arbeit mit mehreren Logins für die Organisation. Für den kostenlosen Tarif ist eine Grenze von acht Teilnehmern je Übung angegeben.</p>
+            </div>
+        </section>
+
+        <section class="card shadow-sm mb-4">
+            <div class="card-header"><h2 class="h4 mb-0" id="vergleich">Die Merkmale nebeneinander</h2></div>
+            <div class="card-body">
+                <div class="table-responsive">
+                    <table class="table table-sm align-middle" data-testid="alternativen-tabelle">
+                        <caption class="small">
+                            Angaben zu funkuebung.de von der öffentlichen Website des Anbieters,
+                            abgerufen am 4. August 2026. Fundstellen im Quelltext dieser Seite.
+                            Maßgeblich bleibt die Website des Anbieters.
+                        </caption>
+                        <thead>
+                            <tr>
+                                <th scope="col">Merkmal</th>
+                                <th scope="col">Von Hand</th>
+                                <th scope="col">Excel-Vorlage</th>
+                                <th scope="col">Dieser Generator</th>
+                                <th scope="col">funkuebung.de</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr><th scope="row">Vorbereitungszeit</th><td>Stunden</td><td>Minuten bis Stunden</td><td>Minuten</td><td>Minuten</td></tr>
+                            <!-- Beleg: https://funkuebung.de/ – abgerufen 2026-08-04 – nennt Registrierung mit E-Mail -->
+                            <tr><th scope="row">Registrierung</th><td>nein</td><td>nein</td><td>nein</td><td>laut Website mit E-Mail-Adresse</td></tr>
+                            <!-- Beleg: https://funkuebung.de/preise – abgerufen 2026-08-04 – dauerhaft kostenloser Tarif, zwei kostenpflichtige Tarife, monatlich kuendbar -->
+                            <tr><th scope="row">Kosten</th><td>keine</td><td>keine</td><td>keine</td><td>kostenloser Tarif mit Grenzen, dazu kostenpflichtige Tarife</td></tr>
+                            <!-- Beleg: https://funkuebung.de/ – abgerufen 2026-08-04 – KI-Meldungen auf Knopfdruck; eine Anzahl vorhandener Meldungen wird nicht ausgewiesen -->
+                            <tr><th scope="row">Übungstexte</th><td>selbst geschrieben</td><td>Umfang der Datei</td><td>Archiv offen einsehbar</td><td>per KI erzeugt, Anzahl je Tarif begrenzt</td></tr>
+                            <!-- Beleg: https://funkuebung.de/ – abgerufen 2026-08-04 – PDF-Uebungsdokument -->
+                            <tr><th scope="row">PDF-Vordrucke</th><td>Papier</td><td>nur selbst gebaut</td><td>ja, befüllt</td><td>ja, Anzahl der Exporte je Tarif begrenzt</td></tr>
+                            <!-- Beleg: https://funkuebung.de/ – abgerufen 2026-08-04 – digitaler Teilnehmerzugang per Code -->
+                            <tr><th scope="row">Teilnehmerzugang</th><td>nein</td><td>nein</td><td>ja, per Link</td><td>ja, per Code</td></tr>
+                            <!-- Beleg: https://funkuebung.de/ – abgerufen 2026-08-04 – Live-Cockpit -->
+                            <tr><th scope="row">Live-Übungsleitung</th><td>nein</td><td>nein</td><td>ja</td><td>ja</td></tr>
+                            <!-- Beleg: https://funkuebung.de/ – abgerufen 2026-08-04 – Im Team arbeiten, mehrere Logins fuer die Organisation -->
+                            <tr><th scope="row">Mehrere Nutzer mit Rollen</th><td>–</td><td>–</td><td>nein, es gibt keine Konten</td><td>ja, je Tarif</td></tr>
+                            <!-- Beleg: https://funkuebung.de/preise – abgerufen 2026-08-04 – Bis zu 8 Teilnehmer pro Uebung im kostenlosen Tarif -->
+                            <tr><th scope="row">Teilnehmer je Übung</th><td>unbegrenzt</td><td>unbegrenzt</td><td>unbegrenzt</td><td>im kostenlosen Tarif bis 8</td></tr>
+                            <tr><th scope="row">Quelloffen</th><td>–</td><td>nein</td><td>ja, EUPL-1.2</td><td>nicht ausgewiesen</td></tr>
+                            <!-- Bewusst keine Aussage über die Datenhaltung Dritter: dazu liegt
+                                 kein nachprüfbarer Beleg vor. Verwiesen wird auf deren Erklärung. -->
+                            <tr><th scope="row">Datenhaltung</th><td>lokal</td><td>lokal</td><td>Firebase, ohne Zugriffsschutz</td><td>siehe Datenschutzerklärung des Anbieters</td></tr>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </section>
+
+        <section class="card shadow-sm mb-4">
+            <div class="card-header"><h2 class="h4 mb-0" id="wann-kommerziell">Wann die kommerzielle Lösung die bessere Wahl ist</h2></div>
+            <div class="card-body">
+                <p>Zwei Bedarfe deckt sie besser ab, und das ist keine Höflichkeitsfloskel.</p>
+                <p><strong>Beschaffung und Ansprechpartner.</strong> Die Website nennt die Möglichkeit, über Rechnung zu beschaffen, ohne privates Zahlungsmittel. Wer aus einem Haushalt beschaffen muss, ein schriftliches Angebot braucht oder einen Vertragspartner mit Zuständigkeit haben will, bekommt das dort. Hier gibt es weder Rechnung noch Vertrag noch einen Anspruch auf Unterstützung.</p>
+                <p><strong>Zusammenarbeit mit Rollen.</strong> Mehrere Logins innerhalb einer Organisation und geteilte Übungen setzen Benutzerkonten voraus. Genau die gibt es hier nicht – und damit auch keine Rechteverwaltung. Wer Übungen im Team vorbereiten und nachvollziehen will, wer was geändert hat, ist mit einer kontobasierten Lösung besser bedient.</p>
+                <p class="mb-0">Dazu kommt ein dritter Punkt für manche Lagen: Wer Meldungen zu einem selbst erfundenen Szenario braucht, das keine Vorlage abdeckt, bekommt sie dort auf Knopfdruck erzeugt. Hier heißt der Weg: eigene Texte schreiben und als Datei hochladen.</p>
+            </div>
+        </section>
+
+        <section class="card shadow-sm mb-4">
+            <div class="card-header"><h2 class="h4 mb-0" id="wann-frei">Wann dieser Generator passt</h2></div>
+            <div class="card-body">
+                <p>Wenn es schnell gehen soll und niemand ein Konto anlegen will. Wenn die Übung mehr als acht Funkstellen hat. Wenn der Übungsbestand vorher einsehbar sein soll, statt erst beim Erzeugen zu erscheinen.</p>
+                <p>Und wenn Quelloffenheit ein Kriterium ist – weil die Organisation selbst betreiben will, weil der Code prüfbar sein soll oder weil die Übungstexte auch dann verfügbar bleiben sollen, wenn das Projekt einmal endet.</p>
+                <p class="mb-0">Für alles andere gilt die nüchterne Antwort: die Wege oben sind keine Gegner. Eine Einheit mit gepflegter Excel-Vorlage hat keinen Grund zu wechseln, und für drei Funkstellen ist Papier schneller als jedes Werkzeug.</p>
+            </div>
+        </section>
+
+        <div class="card">
+            <div class="card-body">
+                <h2 class="h4">Übung jetzt erstellen</h2>
+                <p>
+                    Teilnehmer eintragen, Umfang festlegen, Unterlagen herunterladen – ohne
+                    Konto und ohne Installation.
+                </p>
+                <p class="mb-0">
+                    <a href="../" class="btn btn-primary">Übung erstellen</a>
+                    <a href="../funksprueche/" class="btn btn-outline-primary">Funkspruch-Archiv</a>
+                    <a href="../anleitung/" class="btn btn-outline-primary">Zur Anleitung</a>
+                </p>
+            </div>
+        </div>
+    </article>
+</main>
+
+<footer class="main-footer">
+    <span class="footer-links">
+        <a href="../">Anwendung</a>
+        <a href="../anleitung/">Anleitung</a>
+        <a href="../buchstabiertafel/">Buchstabiertafel</a>
+        <a href="../meldevordruck/">Meldevordruck</a>
+        <a href="../funksprueche/">Funksprüche</a>
+        <a href="../faq/">FAQ</a>
+    </span>
+    <span class="footer-links">
+        <a href="../impressum/">Impressum</a>
+        <a href="../datenschutz/">Datenschutz</a>
+        <a href="mailto:johannes.rudolph@thw-oldenburg.de">Kontakt</a>
+        <a href="https://github.com/wattnpapa/sprechfunk-uebung" target="_blank" rel="noopener noreferrer">GitHub</a>
+        <a href="https://github.com/wattnpapa/sprechfunk-uebung/blob/main/LICENSE" target="_blank" rel="noopener noreferrer">EUPL-1.2-Lizenz</a>
+    </span>
+</footer>
+
+</body>
+
+</html>

--- a/src/pages/funktionen.html
+++ b/src/pages/funktionen.html
@@ -230,6 +230,15 @@
         </section>
 
         <section class="card shadow-sm mb-4">
+        <section class="card shadow-sm mb-4">
+            <div class="card-header"><h2 class="h4 mb-0" id="ohne-konto-bedeutung">Was der Verzicht auf ein Konto bedeutet</h2></div>
+            <div class="card-body">
+                <p>Alle beschriebenen Funktionen stehen ohne Anmeldung bereit, in vollem Umfang und ohne Mengengrenzen. Was das genau heißt und welche Daten dabei gespeichert werden, ist unter <a href="../kostenlos-ohne-anmeldung/">Nutzung ohne Konto und ohne Kosten</a> aufgeschlüsselt.</p>
+                <p>Die Kehrseite gehört dazu: weil es keine Konten gibt, gibt es auch keine Rollen und keinen Zugriffsschutz auf eine Übung. Wer Übungen im Team mit eigenen Zugängen vorbereiten will, ist mit einer kontobasierten Lösung besser bedient – <a href="../alternative/">der Vergleich der vier Wege</a> stellt die Merkmale gegenüber.</p>
+                <p class="mb-0">Für den Ablauf eines Dienstabends spielt das meist keine Rolle. Für die Frage, was in eine Übung eingetragen wird, schon.</p>
+            </div>
+        </section>
+
             <div class="card-header"><h2 class="h4 mb-0" id="grenzen">Was der Generator nicht macht</h2></div>
             <div class="card-body">
                 <p>Die Anwendung erzeugt Übungsunterlagen und begleitet den Verlauf. Sie ersetzt weder Funkgeräte noch die Übungsleitung. Wer die Rufgruppe zuweist, wer einweist und wer eine Nachbesprechung führt, bleibt eine Aufgabe für Menschen.</p>

--- a/src/pages/funkuebung-planen.html
+++ b/src/pages/funkuebung-planen.html
@@ -244,6 +244,15 @@
         </div>
 
         <div class="card mb-3">
+        <section class="card shadow-sm mb-4">
+            <div class="card-header"><h2 class="h4 mb-0" id="werkzeugwahl">Die Wahl des Werkzeugs</h2></div>
+            <div class="card-body">
+                <p>Vor dem ersten Schritt steht eine Entscheidung, die diese Anleitung voraussetzt: womit die Übung vorbereitet wird. Für kleine Lagen genügt Papier, für wiederkehrende Übungen lohnt ein Werkzeug.</p>
+                <p><a href="../alternative/">Eine Gegenüberstellung der vier gängigen Wege</a> zeigt, wo die Unterschiede tatsächlich liegen – bei Registrierung, Mengengrenzen und Quelloffenheit, weniger bei den Kernfunktionen.</p>
+                <p class="mb-0">Wer ohne Konto und ohne Installation arbeiten will, findet die Einzelheiten unter <a href="../kostenlos-ohne-anmeldung/">Funkübung kostenlos und ohne Anmeldung</a>.</p>
+            </div>
+        </section>
+
             <div class="card-header"><h2 class="h4 mb-0" id="fehler">Drei häufige Planungsfehler – und wie du sie vermeidest</h2></div>
             <div class="card-body">
                 <ul class="mb-0">

--- a/src/pages/funkuebung-vorlage.html
+++ b/src/pages/funkuebung-vorlage.html
@@ -225,6 +225,15 @@
             </div>
         </section>
 
+        <section class="card shadow-sm mb-4">
+            <div class="card-header"><h2 class="h4 mb-0" id="welcher-weg">Welcher Weg für welche Einheit</h2></div>
+            <div class="card-body">
+                <p>Eine Vorlage ist nicht der einzige Weg. Von Hand mit Vordrucken, mit einer Tabelle aus dem Ortsverband, mit diesem Generator oder mit einer kommerziellen Web-Anwendung – <a href="../alternative/">die vier Wege im Vergleich</a> stellt sie nach denselben Merkmalen gegenüber.</p>
+                <p>Die Aufstellung benennt für jeden Weg, wann er passt, und für zwei Bedarfe ausdrücklich, wann eine kostenpflichtige Lösung die bessere Wahl ist.</p>
+                <p class="mb-0">Dass die Nutzung hier nichts kostet und kein Konto verlangt, ist unter <a href="../kostenlos-ohne-anmeldung/">kostenlos und ohne Anmeldung</a> im Einzelnen beschrieben – samt der Grenzen, die das mit sich bringt.</p>
+            </div>
+        </section>
+
             <div class="card-header"><h2 class="h4 mb-0" id="drucken">Unterlagen rechtzeitig drucken</h2></div>
             <div class="card-body">
                 <p>Der Druck der Unterlagen dauert bei zehn Funkstellen einige Minuten. Wer die ZIP-Datei erst am Übungsabend öffnet, verliert diese Zeit vor der Einweisung.</p>

--- a/src/pages/kostenlos-ohne-anmeldung.html
+++ b/src/pages/kostenlos-ohne-anmeldung.html
@@ -1,0 +1,186 @@
+<!DOCTYPE html>
+<html lang="de">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Sprechfunkübung kostenlos und ohne Anmeldung erstellen</title>
+    <link rel="icon" type="image/png" href="../assets/favicon.png">
+    <link rel="canonical" href="https://sprechfunk-uebung.de/kostenlos-ohne-anmeldung/">
+    <meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1">
+    <meta name="theme-color" content="#0d6efd">
+
+    <meta name="description" content="Ohne Konto, ohne Installation, ohne Bezahlschranke: was kostenlos hier konkret heißt, welche Übungsdaten gespeichert werden und warum das Projekt offen ist.">
+    <meta name="author" content="Johannes Rudolph">
+
+    <meta property="og:title" content="Sprechfunkübung kostenlos und ohne Anmeldung erstellen">
+    <meta property="og:description" content="Ohne Konto, ohne Installation, ohne Bezahlschranke: was kostenlos hier konkret heißt, welche Übungsdaten gespeichert werden und warum das Projekt offen ist.">
+    <meta property="og:url" content="https://sprechfunk-uebung.de/kostenlos-ohne-anmeldung/">
+    <meta property="og:type" content="article">
+    <meta property="og:locale" content="de_DE">
+    <meta property="og:site_name" content="Sprechfunk Übungsgenerator">
+    <meta property="og:image" content="https://sprechfunk-uebung.de/assets/og-image.png">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">
+    <meta property="og:image:alt" content="Sprechfunk Übungsgenerator – Übungen für den BOS-Sprechfunk erstellen">
+
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Sprechfunkübung kostenlos und ohne Anmeldung erstellen">
+    <meta name="twitter:description" content="Ohne Konto, ohne Installation, ohne Bezahlschranke: was kostenlos hier konkret heißt, welche Übungsdaten gespeichert werden und warum das Projekt offen ist.">
+    <meta name="twitter:image" content="https://sprechfunk-uebung.de/assets/og-image.png">
+
+    <link rel="stylesheet" href="../bundle.css">
+    <link rel="stylesheet" href="../style.css">
+
+    <!-- GoatCounter: cookielose, anonyme Reichweitenmessung -->
+    <script data-goatcounter="https://sprechfunk-uebung.goatcounter.com/count"
+            async src="//gc.zgo.at/count.js"></script>
+
+    <script>
+        // Gleiche Theme-Auswahl wie in der App anwenden (statische Seiten laden kein Bundle).
+        document.addEventListener("DOMContentLoaded", function () {
+            var stored = localStorage.getItem("theme");
+            if (stored) {
+                document.body.setAttribute("data-theme", stored);
+            }
+        });
+    </script>
+</head>
+
+<body data-theme="light">
+<header class="app-header">
+    <div class="container app-header-grid">
+        <div class="app-header-title">
+            <p class="h2 mb-0">
+                <i class="fas fa-broadcast-tower"></i> Sprechfunk Übungsgenerator
+            </p>
+        </div>
+        <div class="app-header-actions d-none d-md-flex">
+            <a href="../" class="btn btn-primary">
+                <i class="fas fa-arrow-left"></i> Zur Anwendung
+            </a>
+            <a href="../anleitung/" class="btn btn-info">
+                <i class="fas fa-book"></i> Anleitung
+            </a>
+            <a href="https://github.com/wattnpapa/sprechfunk-uebung" class="btn btn-dark">
+                <i class="fab fa-github"></i> GitHub
+            </a>
+        </div>
+    </div>
+</header>
+
+<main class="container my-4 app-view-shell">
+    <nav aria-label="Brotkrumennavigation" class="mb-3">
+        <ol class="breadcrumb mb-0">
+            <li class="breadcrumb-item"><a href="../">Startseite</a></li>
+            <li class="breadcrumb-item active" aria-current="page">Kostenlos und ohne Anmeldung</li>
+        </ol>
+    </nav>
+
+    <article>
+        <div class="card mb-3">
+            <div class="card-body">
+                <h1 class="h3">Funkübung kostenlos und ohne Anmeldung</h1>
+                <p class="mb-0">
+                    Diese Seite beschreibt, was <strong>kostenlos</strong> und <strong>ohne
+                    Anmeldung</strong> hier konkret bedeuten – einschließlich der Stellen, an
+                    denen beides einen Preis hat. Wer nur schnell eine Übung braucht, kann
+                    direkt zur <a href="../">Anwendung</a> gehen.
+                </p>
+            </div>
+        </div>
+
+        <section class="card shadow-sm mb-4">
+            <div class="card-header"><h2 class="h4 mb-0" id="was-kostenlos-heisst">Was kostenlos hier konkret heißt</h2></div>
+            <div class="card-body">
+                <p>Vier Dinge, die es nicht gibt: keine Zahlungsdaten, kein Benutzerkonto, keine Testphase, die abläuft, und keine Funktion hinter einer Bezahlschranke.</p>
+                <p>Der letzte Punkt ist der, an dem sich kostenlose Angebote meist unterscheiden. Hier gibt es keine Stufen: Nachrichtenverteilung, alle Funkspruch-Vorlagen, Druckunterlagen, Teilnehmerzugang, Live-Übungsleitung und das Debrief-PDF sind vollständig verfügbar. Es gibt keine Obergrenze für Teilnehmer, Übungen oder Exporte.</p>
+                <p>Was kostenlos nicht einschließt, ist eine Zusage zur Verfügbarkeit. Es gibt keinen Vertrag, kein Service-Level und niemanden, der für eine Störung am Übungsabend einstehen müsste. Wer einen festen Termin hat, erzeugt die Druckunterlagen deshalb vorher und lädt sie als PDF oder ZIP herunter. Dann hängt der Abend nicht an einer fremden Domain, und die Übung läuft auch ohne Verbindung.</p>
+                <p class="mb-0">Es gibt auch keine Werbung und keine Werbe-Cookies. Die Reichweitenmessung läuft über GoatCounter und zählt nur aggregierte Seitenaufrufe, ohne Cookies – so steht es in der <a href="../datenschutz/">Datenschutzerklärung</a>.</p>
+            </div>
+        </section>
+
+        <section class="card shadow-sm mb-4">
+            <div class="card-header"><h2 class="h4 mb-0" id="ohne-konto">Ohne Konto – und was das kostet</h2></div>
+            <div class="card-body">
+                <p>Es gibt keine Registrierung, weil die Anwendung keinen Begriff von Identität hat. Übungsleitung, Teilnehmer und Verwaltung sind reine Ansichten im Browser, keine Rollen mit Rechten.</p>
+                <p>Das spart den Umweg über eine Bestätigungsmail und die Frage, wer die Zugangsdaten der Einheit verwahrt. Es hat aber eine Kehrseite, und die soll hier nicht untergehen: <strong>ohne Identität gibt es auch keinen Zugriffsschutz</strong>.</p>
+                <p class="mb-0">Der Übungscode macht eine Übung auffindbar, er schützt sie nicht. Wer den Link hat, kann die Übung öffnen. Für eine Sprechfunkübung mit Funkrufnamen und Übungstexten ist das vertretbar – für alles andere nicht. Genau deshalb steht in der Datenschutzerklärung der Satz, keine Daten einzutragen, die nicht in einer Übung sichtbar sein sollen.</p>
+            </div>
+        </section>
+
+        <section class="card shadow-sm mb-4">
+            <div class="card-header"><h2 class="h4 mb-0" id="daten">Welche Daten gespeichert werden</h2></div>
+            <div class="card-body">
+                <p>Gespeichert werden die Angaben, die beim Erstellen einer Übung eingetragen werden: Übungsname, die Funkrufnamen der Teilnehmer und die erzeugten Funksprüche. Dazu kommt während der Übung der Fortschritt je Funkstelle und, wenn die Übungsleitung sie nutzt, deren Notizen.</p>
+                <p>Ein <a href="../funkrufnamen/">Funkrufname</a> ist die taktische Adresse einer Funkstelle, keine Person – das ist der Grund, warum eine Übung ohne personenbezogene Daten auskommt. Das Feld ist allerdings freier Text. Wer echte Namen einträgt, macht daraus personenbezogene Daten, und das sollte man lassen.</p>
+                <p class="mb-0">Vorsicht ist besonders bei den Notizen der Übungsleitung angebracht. Sie hängen an einer Funkstelle und enthalten Bewertungen. In einer Einheit mit acht Funkstellen ist ein Rufname faktisch eine Person – und lesbar für jeden, der den Link hat.</p>
+            </div>
+        </section>
+
+        <section class="card shadow-sm mb-4">
+            <div class="card-header"><h2 class="h4 mb-0" id="warum-kostenlos">Warum das Projekt kostenlos ist</h2></div>
+            <div class="card-body">
+                <p>Es ist im Ehrenamt entstanden, aus einem konkreten Bedarf: die Vorbereitung einer Funkübung dauerte länger als die Übung selbst. Was daraus wurde, lag ohnehin auf der Platte – es zu veröffentlichen kostete nichts zusätzlich.</p>
+                <p>Es gibt keine Firma dahinter, kein Investment und keinen Plan, das zu ändern. Damit fällt der übliche Grund für Preisstufen weg: es muss sich nichts rechnen.</p>
+                <p class="mb-0">Der Quellcode steht unter der <a href="https://github.com/wattnpapa/sprechfunk-uebung/blob/main/LICENSE" target="_blank" rel="noopener noreferrer">EUPL-1.2</a> öffentlich auf GitHub. Das ist die Zusicherung, die belastbarer ist als ein Versprechen auf einer Website: sie lässt sich nachlesen.</p>
+            </div>
+        </section>
+
+        <section class="card shadow-sm mb-4">
+            <div class="card-header"><h2 class="h4 mb-0" id="open-source-praktisch">Was Open Source praktisch bedeutet</h2></div>
+            <div class="card-body">
+                <p>Für die meisten Nutzer heißt Open Source erst mal nichts – die Anwendung läuft im Browser, fertig. Vier Dinge werden dadurch aber möglich.</p>
+                <p><strong>Selbst betreiben:</strong> Wer die Anwendung nicht auf einer fremden Domain nutzen will, kann sie mit eigener Firebase-Instanz selbst hosten. Dann liegen die Übungsdaten dort, wo die eigene Organisation sie haben will.</p>
+                <p><strong>Nachprüfen statt glauben:</strong> Was gespeichert wird, steht nicht allein in der Datenschutzerklärung, sondern auch im Code und in den Zugriffsregeln. Die dokumentieren auch die bekannten Restrisiken, statt sie zu verschweigen.</p>
+                <p class="mb-0"><strong>Beitragen:</strong> Eigene Funkspruch-Vorlagen und Verbesserungen können ins Projekt einfließen. <strong>Kein Anbieterrisiko:</strong> Wird das Projekt eingestellt, bleiben Code und Übungstexte verfügbar und weiternutzbar.</p>
+            </div>
+        </section>
+
+        <section class="card shadow-sm mb-4">
+            <div class="card-header"><h2 class="h4 mb-0" id="dienststelle">Einsatz in Dienststelle und Ortsverband</h2></div>
+            <div class="card-body">
+                <p>Die Lizenz erlaubt die Nutzung ausdrücklich, auch dienstlich und auch in Ausbildungsveranstaltungen. Eine Freigabe des Projekts braucht dafür niemand.</p>
+                <p>Was die eigene Organisation vorschreibt, ist eine andere Frage. Vor dem Einsatz auf Dienstrechnern lohnt der Blick in die eigenen Vorgaben zu Webdiensten und Auftragsverarbeitung – die Übungsdaten liegen bei Firebase, also bei einem Anbieter außerhalb der eigenen Organisation.</p>
+                <p class="mb-0">Wer das nicht will, hat den Weg über den Selbstbetrieb. Wer es einfach halten will, nutzt die Anwendung wie sie ist und trägt nichts ein, was nicht in einer Übung sichtbar sein soll.</p>
+            </div>
+        </section>
+
+        <div class="card">
+            <div class="card-body">
+                <h2 class="h4">Übung jetzt erstellen</h2>
+                <p>
+                    Teilnehmer eintragen, Umfang festlegen, Unterlagen herunterladen – ohne
+                    Konto und ohne Installation.
+                </p>
+                <p class="mb-0">
+                    <a href="../" class="btn btn-primary">Übung erstellen</a>
+                    <a href="../funksprueche/" class="btn btn-outline-primary">Funkspruch-Archiv</a>
+                    <a href="../anleitung/" class="btn btn-outline-primary">Zur Anleitung</a>
+                </p>
+            </div>
+        </div>
+    </article>
+</main>
+
+<footer class="main-footer">
+    <span class="footer-links">
+        <a href="../">Anwendung</a>
+        <a href="../anleitung/">Anleitung</a>
+        <a href="../buchstabiertafel/">Buchstabiertafel</a>
+        <a href="../meldevordruck/">Meldevordruck</a>
+        <a href="../funksprueche/">Funksprüche</a>
+        <a href="../faq/">FAQ</a>
+    </span>
+    <span class="footer-links">
+        <a href="../impressum/">Impressum</a>
+        <a href="../datenschutz/">Datenschutz</a>
+        <a href="mailto:johannes.rudolph@thw-oldenburg.de">Kontakt</a>
+        <a href="https://github.com/wattnpapa/sprechfunk-uebung" target="_blank" rel="noopener noreferrer">GitHub</a>
+        <a href="https://github.com/wattnpapa/sprechfunk-uebung/blob/main/LICENSE" target="_blank" rel="noopener noreferrer">EUPL-1.2-Lizenz</a>
+    </span>
+</footer>
+
+</body>
+
+</html>

--- a/src/pages/open-source.html
+++ b/src/pages/open-source.html
@@ -227,6 +227,15 @@
         </section>
 
         <section class="card shadow-sm mb-4">
+        <section class="card shadow-sm mb-4">
+            <div class="card-header"><h2 class="h4 mb-0" id="was-kostenlos-bedeutet">Kostenlos, ohne Konto – und die Kehrseite</h2></div>
+            <div class="card-body">
+                <p>Kostenlos und quelloffen sind zwei Zusagen, die getrennt zu betrachten sind. Was die erste im Einzelnen abdeckt – keine Zahlungsdaten, kein Konto, keine Testphase, keine Bezahlschranke – steht ausführlich unter <a href="../kostenlos-ohne-anmeldung/">Funkübung kostenlos und ohne Anmeldung</a>.</p>
+                <p>Dort steht auch, was das Fehlen eines Kontos kostet: ohne Identität gibt es keinen Zugriffsschutz und keine Rechteverwaltung. Wer das nicht tragen kann, findet unter <a href="../alternative/">den Wegen zur Sprechfunkübung im Vergleich</a> die Merkmale der Alternativen nebeneinander.</p>
+                <p class="mb-0">Beide Seiten benennen die Grenzen dieses Projekts ausdrücklich. Eine Übersicht, die nur Vorteile aufzählt, hilft bei der Entscheidung nicht weiter.</p>
+            </div>
+        </section>
+
             <div class="card-header"><h2 class="h4 mb-0" id="selbst-betreiben">Betrieb auf eigener Infrastruktur</h2></div>
             <div class="card-body">
                 <p>Wer die Anwendung im eigenen Netz betreiben will, kann das Repository klonen und selbst bauen. Nötig sind Node.js und eine Firebase-Konfiguration für die Datenhaltung.</p>

--- a/tests/seo/SchemaGraph.test.ts
+++ b/tests/seo/SchemaGraph.test.ts
@@ -95,7 +95,7 @@ function alleSchluessel(wert: unknown, treffer: string[] = []): string[] {
 
 describe("Schema-Graph je Seite", () => {
     it("die Registry deckt alle 30 ausgelieferten URLs ab", () => {
-        expect(SITE_PAGES).toHaveLength(37);
+        expect(SITE_PAGES).toHaveLength(39);
     });
 
     for (const page of SITE_PAGES) {

--- a/tests/seo/Wettbewerbsvergleich.test.ts
+++ b/tests/seo/Wettbewerbsvergleich.test.ts
@@ -1,0 +1,194 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { SITE_PAGES } from "../../scripts/site-pages.mjs";
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore -- reine JS-Hilfsmodule ohne Typdeklarationen, absichtlich .mjs
+import { plainText, zaehleWoerter } from "../../scripts/lib/page-metadata.mjs";
+
+interface Registrierung {
+    slug: string;
+    kurzGesagt?: string;
+    faq?: { q: string; a: string }[];
+}
+
+const ROOT = path.resolve(__dirname, "..", "..");
+const lese = (datei: string) => readFileSync(path.join(ROOT, datei), "utf8");
+
+const ALTERNATIVE = "src/pages/alternative.html";
+const KOSTENLOS = "src/pages/kostenlos-ohne-anmeldung.html";
+const REGISTER = "seo/wettbewerbsvergleich.md";
+
+/** Der namentlich genannte Wettbewerber. */
+const WETTBEWERBER = "funkuebung.de";
+
+describe("Belegpflicht für Aussagen über Dritte", () => {
+    it("nennt den Wettbewerber ausschließlich auf der Vergleichsseite", () => {
+        // Auf anderen Seiten hätte eine Nennung keinen Beleg-Kommentar und
+        // wäre damit nicht nachprüfbar.
+        const seiten = ["src/index.html", KOSTENLOS, "src/pages/open-source.html",
+            "src/pages/funktionen.html", "src/pages/faq.html", "src/pages/funkuebung-vorlage.html"];
+        for (const seite of seiten) {
+            expect(lese(seite), `${seite} nennt ${WETTBEWERBER} ohne Beleg`)
+                .not.toContain(WETTBEWERBER);
+        }
+    });
+
+    it("belegt die Aussagen der Vergleichstabelle mit URL und Abrufdatum", () => {
+        const html = lese(ALTERNATIVE);
+        const tabelle = /<table[^>]*data-testid="alternativen-tabelle"[\s\S]*?<\/table>/.exec(html)?.[0];
+        expect(tabelle, "Vergleichstabelle fehlt").toBeTruthy();
+
+        const belege = [...tabelle!.matchAll(
+            /<!--\s*Beleg:\s*(https:\/\/[^\s]+)\s*–\s*abgerufen\s*(\d{4}-\d{2}-\d{2})\s*–\s*([\s\S]*?)-->/g
+        )];
+        expect(belege.length, "zu wenige Beleg-Kommentare").toBeGreaterThanOrEqual(8);
+
+        for (const [, url, datum] of belege) {
+            expect(url).toContain(WETTBEWERBER);
+            expect(datum).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+        }
+    });
+
+    it("trägt das Abrufdatum sichtbar an der Tabelle", () => {
+        const html = lese(ALTERNATIVE);
+        const caption = /<caption[\s\S]*?<\/caption>/.exec(html)?.[0] ?? "";
+        expect(caption).toMatch(/abgerufen am \d{1,2}\. \w+ \d{4}/);
+        expect(caption).toContain(WETTBEWERBER);
+    });
+
+    it("nennt keine Beträge auf der Vergleichsseite", () => {
+        // Preise veralten. Die Seite nennt nur die Tarifstruktur und verlinkt
+        // die Preisseite des Anbieters; die Beträge stehen datiert im Register.
+        const text = plainText(lese(ALTERNATIVE));
+        expect(text).not.toMatch(/\d+[,.]\d{2}\s*€/);
+        expect(text).not.toMatch(/€\s*\d/);
+        expect(text).not.toMatch(/\d+\s*Euro/i);
+    });
+
+    it("verzichtet auf herabsetzende Wertungen", () => {
+        const text = plainText(lese(ALTERNATIVE)).toLowerCase();
+        for (const wort of ["schlechter", "überteuert", "umständlich", "unseriös",
+            "veraltet", "mangelhaft"]) {
+            expect(text, `Wertung „${wort}“ auf der Vergleichsseite`).not.toContain(wort);
+        }
+    });
+
+    it("benennt mindestens zwei Punkte für die Alternative", () => {
+        const html = lese(ALTERNATIVE);
+        expect(html).toContain('id="wann-kommerziell"');
+        const abschnitt = /id="wann-kommerziell"[\s\S]*?<\/section>/.exec(html)?.[0] ?? "";
+        const gruende = [...abschnitt.matchAll(/<strong>[^<]+<\/strong>/g)];
+        expect(gruende.length).toBeGreaterThanOrEqual(2);
+    });
+});
+
+describe("Quellenregister", () => {
+    const register = lese(REGISTER);
+
+    it("führt jede Beleg-URL der Seite auch im Register", () => {
+        const urls = new Set([...lese(ALTERNATIVE).matchAll(/<!--\s*Beleg:\s*(https:\/\/[^\s]+)/g)]
+            .map(treffer => treffer[1] as string));
+        expect(urls.size).toBeGreaterThan(0);
+        for (const url of urls) {
+            expect(register, `${url} fehlt im Register`).toContain(url);
+        }
+    });
+
+    it("nennt Erhebung, fachliche Bestätigung und rechtliche Freigabe", () => {
+        expect(register).toContain("Erhebung");
+        expect(register).toContain("Fachliche Bestätigung");
+        expect(register).toContain("Rechtliche Freigabe");
+    });
+
+    it("nennt eine Wiedervorlage in der Zukunft der Erhebung", () => {
+        const erhebung = /Letzte Erhebung: (\d{4}-\d{2}-\d{2})/.exec(register)?.[1];
+        const wieder = /Nächste Wiedervorlage: (\d{4}-\d{2}-\d{2})/.exec(register)?.[1];
+        expect(erhebung).toBeTruthy();
+        expect(wieder).toBeTruthy();
+        expect(new Date(wieder!).getTime()).toBeGreaterThan(new Date(erhebung!).getTime());
+    });
+
+    it("hält fest, was bewusst nicht behauptet wird", () => {
+        expect(register).toContain("Bewusst nicht behauptet");
+    });
+});
+
+describe("Eigene Aussagen deckungsgleich mit der Datenschutzerklärung", () => {
+    const datenschutz = plainText(lese("src/pages/datenschutz.html"));
+    const seite = plainText(lese(KOSTENLOS));
+
+    it("nennt dieselben gespeicherten Daten wie die Datenschutzerklärung", () => {
+        for (const begriff of ["Übungsname", "Funkrufnamen", "Funksprüche"]) {
+            expect(datenschutz, `Datenschutz nennt ${begriff} nicht mehr`).toContain(begriff);
+            expect(seite, `Seite nennt ${begriff} nicht`).toContain(begriff);
+        }
+    });
+
+    it("übernimmt den Hinweis, nichts Schützenswertes einzutragen", () => {
+        expect(datenschutz).toContain("nicht in einer Übung sichtbar sein sollen");
+        expect(seite).toContain("nicht in einer Übung sichtbar sein sollen");
+    });
+
+    it("nennt GoatCounter und die Cookiefreiheit wie die Erklärung", () => {
+        expect(datenschutz).toContain("GoatCounter");
+        expect(seite).toContain("GoatCounter");
+        expect(datenschutz).toContain("keine Cookies");
+        expect(seite).toContain("ohne Cookies");
+    });
+
+    it("sagt keine Speicherdauer zu, weil die Erklärung keine nennt", () => {
+        // Es gibt keine TTL und keinen Aufräumjob. Eine Dauer auf der Seite wäre
+        // eine Zusage, die weder Erklärung noch Code hergeben.
+        expect(datenschutz).not.toMatch(/Speicherdauer|gelöscht nach|Löschfrist/);
+        expect(seite).not.toMatch(/Speicherdauer|gelöscht nach|Löschfrist|\d+\s*Tage[n]? gespeichert/);
+    });
+
+    it("verschweigt den fehlenden Zugriffsschutz nicht", () => {
+        // firestore.rules dokumentiert das als Restrisiko 1. Eine Seite, die
+        // „ohne Anmeldung“ bewirbt und das auslässt, wäre irreführend.
+        expect(lese("firestore.rules")).toContain("kein Zugriffsschutz");
+        expect(seite).toContain("keinen Zugriffsschutz");
+    });
+});
+
+describe("Umfang und Format der neuen Seiten", () => {
+    it.each([
+        ["alternative", ALTERNATIVE],
+        ["kostenlos-ohne-anmeldung", KOSTENLOS]
+    ])("/%s/ hat mindestens 900 Wörter", (slug, datei) => {
+        // Gezählt wird, was auf der ausgelieferten Seite steht: der Quelltext
+        // plus „Kurz gesagt“ und die FAQ, die der Build aus der Registry
+        // einsetzt. Beides ist sichtbarer Inhalt – check-content-quality.mjs
+        // zählt es ebenso. Nur den Quelltext zu messen wäre zu streng und
+        // würde außerdem eine zweite, abweichende Zählweise etablieren.
+        const main = /<main[\s\S]*?<\/main>/.exec(lese(datei))?.[0] ?? "";
+        const seite = (SITE_PAGES as Registrierung[]).find(eintrag => eintrag.slug === slug);
+        expect(seite, `${slug} fehlt in der Registry`).toBeTruthy();
+
+        const ausRegistry = [
+            seite!.kurzGesagt ?? "",
+            ...(seite!.faq ?? []).flatMap(eintrag => [eintrag.q, eintrag.a])
+        ].join(" ");
+
+        const woerter = zaehleWoerter(plainText(main)) + zaehleWoerter(ausRegistry);
+        expect(woerter).toBeGreaterThanOrEqual(900);
+    });
+
+    it.each([
+        ["/alternative/", ALTERNATIVE],
+        ["/kostenlos-ohne-anmeldung/", KOSTENLOS]
+    ])("%s trägt den Wettbewerbernamen nicht in Titel, h1 oder Description", (_name, datei) => {
+        const html = lese(datei);
+        const felder: [string, string][] = [
+            ["Titel", /<title>([^<]*)<\/title>/.exec(html)?.[1] ?? ""],
+            ["h1", /<h1[^>]*>([\s\S]*?)<\/h1>/.exec(html)?.[1] ?? ""],
+            ["Description", /<meta name="description" content="([^"]*)"/.exec(html)?.[1] ?? ""]
+        ];
+        for (const [feld, wert] of felder) {
+            expect(wert, `${feld} nennt den Wettbewerber`).not.toContain(WETTBEWERBER);
+        }
+    });
+});


### PR DESCRIPTION
> ⚠️ **Nicht mergen, solange die rechtliche Freigabe offen ist.** Siehe Abschnitt „Rechtliche Freigabe" unten. `/alternative/` nennt einen Wettbewerber namentlich; das ist eine Entscheidung, die ich nicht treffen kann.

## Was

Zwei neue Seiten plus ein Quellenregister und eine Wiedervorlage.

| Seite | Wörter | Titel | Desc | Eingehend |
| --- | ---: | ---: | ---: | ---: |
| `/kostenlos-ohne-anmeldung/` | 945 | 54 | 156 | 5 |
| `/alternative/` | 1120 | 56 | 149 | 4 |

## Belege statt Behauptungen

Ich hatte über funkuebung.de **selbst nichts verifiziert** — die Angaben in der Aufgabenstellung stammten aus einer Analyse, nicht aus meiner Beobachtung. Deshalb habe ich die öffentlichen Seiten abgerufen und jede Aussage einzeln belegt.

**Zwei Quellen, abgerufen 2026-08-04:** `https://funkuebung.de/` und `https://funkuebung.de/preise`. Zehn Aussagen, jede mit URL und Abrufdatum als Kommentar direkt über ihrer Tabellenzeile, das Abrufdatum zusätzlich sichtbar in der `<caption>`.

**Fünf Dinge behaupte ich bewusst nicht**, weil kein Beleg vorliegt:

| Nicht behauptet | Grund |
| --- | --- |
| Konkrete Beträge auf der Seite | Preise veralten; ein veralteter Betrag ist ein Irreführungsrisiko. Die Seite nennt die Tarifstruktur mit Abrufdatum und verlinkt die Preisseite. Die Beträge stehen datiert im Register. |
| Datenhaltung des Anbieters | Nicht geprüft. Die Tabelle verweist auf dessen Datenschutzerklärung, statt eine Aussage zu treffen. |
| Gastzugang ohne Konto | `https://funkuebung.de/registrieren` lieferte HTTP 404. Ich rate keine URLs und keine Sachverhalte. |
| Anzahl verfügbarer Meldungen | Wird nicht als Zahl ausgewiesen. Die Tabelle sagt genau das. |
| Quelloffenheit des Anbieters | Nicht ausgewiesen. Die Tabelle sagt „nicht ausgewiesen", nicht „nein". |

**Stärken des Wettbewerbers sind benannt**, nicht weggelassen: per KI erzeugte Meldungen, Team-Arbeit mit mehreren Logins, Beschaffung über Rechnung, monatlich kündbar. Zwei eigene Abschnitte sagen, wann die kommerzielle Lösung die bessere Wahl ist — Beschaffung mit Ansprechpartner und Zusammenarbeit mit Rollen — plus ein dritter Punkt zu KI-Meldungen für selbst erfundene Szenarien.

## Zwei Dinge, die dein Auftrag anders vorsah

**1. Keine Speicherdauer.** Der Auftrag verlangt „welche Daten in Firestore landen, **wie lange**". `/datenschutz/` nennt keine Dauer, und im Code gibt es weder TTL noch Aufräumjob. Du hast dazu geschrieben, dass in Übungen keine personenbezogenen Daten liegen und du sie behalten kannst, so lange du willst — rechtlich gebe ich dir recht, deshalb steht keine Dauer auf der Seite und `/datenschutz/` bleibt unverändert. Ein Test hält fest, dass die Seite keine Dauer zusagt.

**2. Die Kehrseite von „ohne Anmeldung" steht drauf.** `firestore.rules` dokumentiert selbst als Restrisiko: jeder mit dem öffentlichen API-Key kann Übungen lesen, anlegen und löschen; der Übungscode ist ein Auffindbarkeits-, kein Zugriffsschutz. Eine Seite, die „kostenlos, ohne Konto" bewirbt und das auslässt, wäre genau die Art Darstellung, die dein Auftrag beim Wettbewerber verbietet. Besonders hingewiesen wird auf die Notizen der Übungsleitung: sie hängen an einer Funkstelle, enthalten Bewertungen, und in einer Einheit mit acht Funkstellen ist ein Rufname faktisch eine Person.

## Ein Fehler in meiner eigenen Prüfung aus AP-05

Die Obergrenze von 40 internen Links je Seite traf den Hub: dessen Kartenliste verlinkt jede Seite und lag bei 37 Seiten bei 42 Links. Die Regel zielt darauf, redaktionelle Seiten nicht mit Links zuzustopfen — auf eine Seite, deren Inhalt eine Linkliste *ist*, passt sie nicht und wäre dauerhaft verletzt. Der Hub ist jetzt ausgenommen, begründet im Code; für jede andere Seite gilt die Grenze unverändert.

## Abnahmekriterien

- [x] Beide Seiten ≥ 900 Wörter, Seitenformat aus AP-06 vollständig
- [x] Jede Aussage über funkuebung.de mit Beleg-Kommentar (URL + Abrufdatum) im Quelltext — Test erzwingt ≥ 8 Belege mit ISO-Datum
- [x] `seo/wettbewerbsvergleich.md` vollständig, Wiedervorlage als Issue #75 angelegt (fällig 2027-02-04)
- [x] Eigene Datenaussagen deckungsgleich mit `/datenschutz/` — als Test, nicht als manuelle Prüfung
- [x] Mindestens zwei Punkte für die Alternative benannt (drei sind es)
- [x] Keine Preisangabe ohne sichtbares Abrufdatum — auf der Seite gibt es gar keine Beträge, ein Test verbietet sie
- [ ] **Rechtliche Freigabe — offen, siehe unten**

## Rechtliche Freigabe

Vergleichende Werbung ist nach § 6 UWG zulässig, wenn sie sachlich, objektiv nachprüfbar und nicht herabsetzend ist. Was ich dafür getan habe:

- Alle Merkmale von der öffentlichen Website des Anbieters, mit Fundstelle und Datum
- Keine Wertung; ein Test verbietet „schlechter", „überteuert", „umständlich", „unseriös", „veraltet", „mangelhaft"
- Stärken des Wettbewerbers und zwei Fälle, in denen er die bessere Wahl ist
- Kein Wettbewerbername in Titel, `h1` oder Description; Nennung ausschließlich auf der Vergleichsseite (Test)
- Keine erfundenen Nutzerzahlen, keine Testimonials

**Was ich nicht leisten kann:** eine juristische Bewertung. Ob die Gegenüberstellung in dieser Form zulässig ist, muss jemand mit Rechtskenntnis entscheiden. `seo/wettbewerbsvergleich.md` führt „Fachliche Bestätigung" und „Rechtliche Freigabe" als offene Zeilen und hält fest, dass `/alternative/` bis dahin nicht gemergt werden darf.

Falls du das Risiko nicht tragen willst: `/kostenlos-ohne-anmeldung/` ist davon unabhängig und enthält ausschließlich Aussagen über die eigene Anwendung. Die Seite lässt sich einzeln übernehmen; sag Bescheid, dann trenne ich den PR auf.

## Wie zu prüfen

```bash
npm ci && npm run build
npx vitest run tests/seo/Wettbewerbsvergleich.test.ts
node scripts/check-content-quality.mjs && node scripts/check-internal-links.mjs
npm run perf:budget && npx playwright test
```

Grün: Build, Lint, **1400** Unit-Tests (55 Dateien), **396** Playwright-Tests, `content:check` (36 Seiten, 0 Verstöße), `links:check` (369 Links, 0 Verstöße), `perf:budget`.

## Offen aus dem Programm

AP-09 nennt **AP-01 als Voraussetzung**; das Paket wurde nie ausgeführt. Eine harte Abhängigkeit sehe ich nicht, die Voraussetzung ist aber formal offen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
