### PR TITLE
seo(AP-11): erfassungsbogen.app kontextuell verlinken

### DIFF
--- a/src/pages/funkuebung-katastrophenschutz.html
+++ b/src/pages/funkuebung-katastrophenschutz.html
@@ -208,6 +208,7 @@
                 <p>Die Übung folgt der vorhandenen Struktur, weil die Funkstellen mit ihren realen Rufnamen eingetragen werden. Eine Einsatzeinheit mit vier Fahrzeugen ergibt vier Funkstellen plus Führung.</p>
                 <p>Bei größeren Verbänden lohnt die Aufteilung in Abschnitte mit je eigener Rufgruppe. Eine Übung mit zwanzig Stellen auf einem Kanal erzeugt fast nur Wartezeit.</p>
                 <p>Die Führungsstelle bekommt dabei bewusst mehr Nachrichten als die übrigen Stellen. Das entspricht der Einsatzrealität und macht die Belastung der Führung im Nachrichtenplan sichtbar.</p>
+                <p>Zur Übungsvorbereitung im Zug- oder Verbandsrahmen gehört auch, Personal, Stärke und Fahrzeuge der beteiligten Einheiten zu erfassen. Genau dafür gibt es den <a href="https://erfassungsbogen.app" target="_blank" rel="noopener noreferrer">digitalen Einheiten-Erfassungsbogen</a>, ein zweites Werkzeug desselben Autors: kostenlos, ohne Anmeldung und komplett offline im Browser. Der ausgefüllte Bogen lässt sich als PDF drucken und per QR-Code ohne Netz an ein anderes Gerät übergeben. Wer Fahrzeuge und Personal so beisammen hat, hat damit auch die Funkstellen für die Teilnehmerliste der Übung.</p>
             </div>
         </section>
 

--- a/src/pages/open-source.html
+++ b/src/pages/open-source.html
@@ -243,6 +243,14 @@
             </div>
         </section>
 
+        <section class="card shadow-sm mb-4">
+            <div class="card-header"><h2 class="h4 mb-0" id="projektumfeld">Aus demselben Projektumfeld</h2></div>
+            <div class="card-body">
+                <p>Nach denselben Grundsätzen – kostenlos, quelloffen unter EUPL-1.2, ohne Anmeldung – ist auch der <a href="https://erfassungsbogen.app" target="_blank" rel="noopener noreferrer">digitale Einheiten-Erfassungsbogen</a> entstanden. Er erfasst Einheit, Einsatz, Personal, Fahrzeuge und Sofortbedarf im Browser, zählt die Stärke zusammen und funktioniert komplett offline.</p>
+                <p class="mb-0">Der ausgefüllte Bogen lässt sich als PDF drucken und per QR-Code von Gerät zu Gerät übergeben, ganz ohne Internetverbindung. Der Quellcode liegt wie bei diesem Projekt öffentlich auf <a href="https://github.com/wattnpapa/erfassungsbogen" target="_blank" rel="noopener noreferrer">GitHub</a>.</p>
+            </div>
+        </section>
+
 <div class="card-body">
                 <h2 class="h4">Einfach ausprobieren – mehr braucht es nicht</h2>
                 <p>

--- a/tests/seo/ErfassungsbogenLink.test.ts
+++ b/tests/seo/ErfassungsbogenLink.test.ts
@@ -15,6 +15,7 @@ import { SITE_PAGES } from "../../scripts/site-pages.mjs";
 const root = path.resolve(__dirname, "..", "..");
 
 const ZIEL = "https://erfassungsbogen.app";
+const ZIEL_HOST = "erfassungsbogen.app";
 const REPO = "https://github.com/wattnpapa/erfassungsbogen";
 const ERWARTETE_SEITEN = ["funkuebung-katastrophenschutz", "open-source"];
 
@@ -29,10 +30,25 @@ function leseSeite(source: string): string {
     return readFileSync(path.join(root, "src", source), "utf8");
 }
 
-function linksAuf(html: string, ziel: string): string[] {
-    return [...html.matchAll(/<a\s[^>]*>/gi)]
-        .map(treffer => treffer[0])
-        .filter(tag => tag.includes(`href="${ziel}`));
+/** Alle <a>-Tags der Seite mit ihrem href-Wert. */
+function ankerTags(html: string): { tag: string; href: string }[] {
+    return [...html.matchAll(/<a\s[^>]*href="([^"]*)"[^>]*>/gi)]
+        .map(treffer => ({ tag: treffer[0], href: treffer[1] }));
+}
+
+/** Hostname eines href, oder "" bei relativen Zielen. */
+function hostVon(href: string): string {
+    try {
+        return new URL(href).hostname;
+    } catch {
+        return "";
+    }
+}
+
+function erfassungsbogenLinks(html: string): { tag: string; href: string }[] {
+    // Exakter Host-Vergleich statt Teilstring: "erfassungsbogen.app.example"
+    // soll nicht zählen (CodeQL js/incomplete-url-substring-sanitization).
+    return ankerTags(html).filter(anker => hostVon(anker.href) === ZIEL_HOST);
 }
 
 describe("Kontextuelle Links auf erfassungsbogen.app (AP-11)", () => {
@@ -42,19 +58,21 @@ describe("Kontextuelle Links auf erfassungsbogen.app (AP-11)", () => {
         expect(seite, `Seite "${slug}" fehlt in der Registry`).toBeTruthy();
 
         const html = leseSeite(seite!.source);
-        const links = linksAuf(html, ZIEL);
+        const links = erfassungsbogenLinks(html);
         expect(links.length, `${slug} verlinkt ${ZIEL} nicht`).toBeGreaterThanOrEqual(1);
 
         // Eigenes Projekt, redaktionell gewollt – ein nofollow wäre falsch.
-        for (const tag of links) {
-            expect(tag, `${slug} setzt nofollow auf den eigenen Projektlink`)
+        for (const anker of links) {
+            expect(anker.tag, `${slug} setzt nofollow auf den eigenen Projektlink`)
                 .not.toMatch(/rel="[^"]*nofollow[^"]*"/i);
         }
     });
 
     it("verlinkt auf /open-source/ auch das Repository", () => {
         const seite = seiten.find(eintrag => eintrag.slug === "open-source")!;
-        expect(linksAuf(leseSeite(seite.source), REPO).length).toBeGreaterThanOrEqual(1);
+        const repoLinks = ankerTags(leseSeite(seite.source))
+            .filter(anker => anker.href === REPO);
+        expect(repoLinks.length).toBeGreaterThanOrEqual(1);
     });
 
     it("verlinkt erfassungsbogen.app von genau zwei Seiten aus", () => {
@@ -62,7 +80,7 @@ describe("Kontextuelle Links auf erfassungsbogen.app (AP-11)", () => {
         // auf weiteren Seiten auf, ist das eine bewusste redaktionelle
         // Entscheidung und gehört hier ergänzt.
         const verlinkende = seiten
-            .filter(seite => leseSeite(seite.source).includes(ZIEL))
+            .filter(seite => erfassungsbogenLinks(leseSeite(seite.source)).length > 0)
             .map(seite => seite.slug)
             .sort();
 

--- a/tests/seo/ErfassungsbogenLink.test.ts
+++ b/tests/seo/ErfassungsbogenLink.test.ts
@@ -1,0 +1,71 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+// @ts-expect-error – reines JS-Modul ohne Typdeklaration, bewusst geteilt mit dem Build
+import { SITE_PAGES } from "../../scripts/site-pages.mjs";
+
+/**
+ * erfassungsbogen.app ist ein zweites BOS-Werkzeug desselben Autors und wird
+ * bewusst nur von genau zwei Stellen aus verlinkt – als redaktioneller
+ * Fließtext-Link, nicht als Footer- oder Navigationslink auf allen Seiten
+ * (AP-11). Der Test hält beide Zusicherungen fest: die Links existieren, und
+ * es kommen nicht schleichend weitere Seiten dazu.
+ */
+
+const root = path.resolve(__dirname, "..", "..");
+
+const ZIEL = "https://erfassungsbogen.app";
+const REPO = "https://github.com/wattnpapa/erfassungsbogen";
+const ERWARTETE_SEITEN = ["funkuebung-katastrophenschutz", "open-source"];
+
+interface SitePage {
+    slug: string;
+    source: string;
+}
+
+const seiten = SITE_PAGES as SitePage[];
+
+function leseSeite(source: string): string {
+    return readFileSync(path.join(root, "src", source), "utf8");
+}
+
+function linksAuf(html: string, ziel: string): string[] {
+    return [...html.matchAll(/<a\s[^>]*>/gi)]
+        .map(treffer => treffer[0])
+        .filter(tag => tag.includes(`href="${ziel}`));
+}
+
+describe("Kontextuelle Links auf erfassungsbogen.app (AP-11)", () => {
+
+    it.each(ERWARTETE_SEITEN)("/%s/ verlinkt erfassungsbogen.app im Fließtext", slug => {
+        const seite = seiten.find(eintrag => eintrag.slug === slug);
+        expect(seite, `Seite "${slug}" fehlt in der Registry`).toBeTruthy();
+
+        const html = leseSeite(seite!.source);
+        const links = linksAuf(html, ZIEL);
+        expect(links.length, `${slug} verlinkt ${ZIEL} nicht`).toBeGreaterThanOrEqual(1);
+
+        // Eigenes Projekt, redaktionell gewollt – ein nofollow wäre falsch.
+        for (const tag of links) {
+            expect(tag, `${slug} setzt nofollow auf den eigenen Projektlink`)
+                .not.toMatch(/rel="[^"]*nofollow[^"]*"/i);
+        }
+    });
+
+    it("verlinkt auf /open-source/ auch das Repository", () => {
+        const seite = seiten.find(eintrag => eintrag.slug === "open-source")!;
+        expect(linksAuf(leseSeite(seite.source), REPO).length).toBeGreaterThanOrEqual(1);
+    });
+
+    it("verlinkt erfassungsbogen.app von genau zwei Seiten aus", () => {
+        // Kein Footer- oder Navigationslink auf allen Seiten: taucht der Link
+        // auf weiteren Seiten auf, ist das eine bewusste redaktionelle
+        // Entscheidung und gehört hier ergänzt.
+        const verlinkende = seiten
+            .filter(seite => leseSeite(seite.source).includes(ZIEL))
+            .map(seite => seite.slug)
+            .sort();
+
+        expect(verlinkende).toEqual([...ERWARTETE_SEITEN].sort());
+    });
+});


### PR DESCRIPTION
## Was

Zwei redaktionelle Fließtext-Links auf [erfassungsbogen.app](https://erfassungsbogen.app), das zweite BOS-Ausbildungswerkzeug desselben Autors (digitaler Einheiten-Erfassungsbogen, EUPL-1.2, läuft offline im Browser):

1. **/funkuebung-katastrophenschutz/** – im Abschnitt „Bereitschaften, Einsatzeinheiten und Züge": Wer eine Funkübung im Zug- oder Verbandsrahmen plant, erfasst vorher Personal, Stärke und Fahrzeuge der Einheiten – genau dafür ist der Erfassungsbogen da (kostenlos, ohne Anmeldung, Übergabe per QR-Code ohne Netz).
2. **/open-source/** – neuer Abschnitt „Aus demselben Projektumfeld": gleiche Philosophie (kostenlos, quelloffen unter EUPL-1.2, ohne Anmeldung), verlinkt App und [Repository](https://github.com/wattnpapa/erfassungsbogen).

Bewusst **kein** Footer- oder Navigationslink auf allen Seiten und **kein** `rel="nofollow"` (eigenes Projekt, redaktionell gewollt). Alle genannten Eigenschaften sind auf erfassungsbogen.app bzw. im dortigen README nachlesbar („funktioniert komplett offline", „per QR-Code ohne Internetverbindung", „keine Anmeldung, kein Server, keine Cloud", EUPL-1.2, Formularbereiche Einheit/Einsatz/Personal/Fahrzeuge/Sofortbedarf).

## Warum

Beide Werkzeuge richten sich an dieselbe Zielgruppe (Ausbildung und Übungsvorbereitung in BOS-Einheiten) und ergänzen sich im Arbeitsablauf: erst Einheiten erfassen, dann die Funkübung mit den erfassten Funkstellen planen. Der Link vom Open-Source-Kontext aus macht das gemeinsame Projektumfeld sichtbar.

## Wie zu prüfen

- `npx vitest run tests/seo/ErfassungsbogenLink.test.ts` – neuer Test: beide Seiten verlinken `https://erfassungsbogen.app` ohne nofollow, /open-source/ zusätzlich das Repo, und **genau zwei** Seiten führen den Link (kein schleichender Footer-Link).
- `npm run lint` ✅, `npx vitest run` ✅ (1627 Tests), `npm run build` ✅
- `node scripts/check-internal-links.mjs --strict` ✅ – weiterhin 0 Verstöße (externe Links zählen dort nicht als Fließtext-Links, die Regeln bleiben unberührt).
- Keine Änderung an `scripts/site-pages.mjs` nötig – die `sources`-Einträge beider Seiten existieren bereits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)