### PR TITLE
test(e2e): Archiv-Round-Trip gegen den Firestore-Mock – macht den Deploy wieder grün

### DIFF
--- a/e2e/funkspruch-archiv.spec.ts
+++ b/e2e/funkspruch-archiv.spec.ts
@@ -103,8 +103,20 @@ test.describe("Download und Wiedereinlesen im Generator", () => {
         });
     }
 
-    test("@seo die heruntergeladene Datei lässt sich im Generator wieder einlesen", async ({ page, request }) => {
+    test("@seo die heruntergeladene Datei lässt sich im Generator wieder einlesen", async ({ page, context, request }) => {
         const inhalt = await (await request.get(`/assets/funksprueche-${kleinste.slug}.txt`)).text();
+
+        // Firestore-Mock einschalten, wie es app.spec.ts für alle Generator-Tests
+        // tut. Ohne ihn spricht der Test die echte Datenbank an: lokal geht das
+        // gut (die committete Config funktioniert) und legt nebenbei Übungen im
+        // Produktivbestand an – in CI wird firebase-config.js aus Secrets erzeugt,
+        // das Speicherversprechen löst nie auf, und die Generierung bleibt ohne
+        // Fehlermeldung vor den Links stehen. Genau daran ist der Deploy seit
+        // AP-08 gescheitert.
+        await context.addInitScript(() => {
+            window.localStorage.setItem("useFirestoreEmulator", "1");
+            window.localStorage.setItem("e2eFirestoreSeed", JSON.stringify({}));
+        });
 
         await page.goto("/");
 
@@ -121,7 +133,18 @@ test.describe("Download und Wiedereinlesen im Generator", () => {
             await felder.nth(i).fill(namen[i] ?? `Heros Beispielstadt 9${i}/9${i}`);
         }
         await page.locator("#nameDerUebung").fill("Archiv-Round-Trip");
+
+        // Verteilung ausdrücklich setzen statt sie zu erben: validateSpruchVerteilung
+        // bricht ab, sobald „Sprüche pro Teilnehmer" kleiner ist als Anmeldung
+        // plus „an Alle" plus „an Mehrere". Die Prozentfelder rechnen die
+        // versteckten Anzahlfelder bei jedem input-Ereignis neu, deshalb zuerst
+        // die Anzahl, dann die Prozentsätze – und danach die Probe darauf.
         await page.locator("#spruecheProTeilnehmer").fill("3");
+        await page.locator("#prozentAnAlle").fill("0");
+        await page.locator("#prozentAnMehrere").fill("0");
+        await page.locator("#prozentAnBuchstabieren").fill("0");
+        await expect(page.locator("#spruecheAnAlle")).toHaveValue("0");
+        await expect(page.locator("#spruecheAnMehrere")).toHaveValue("0");
 
         await page.locator("#optionUpload").check();
         await page.locator("#funksprueche").setInputFiles({
@@ -135,6 +158,13 @@ test.describe("Download und Wiedereinlesen im Generator", () => {
         // Die Übung entsteht: ohne lesbare Datei bliebe der Nachrichtenpool leer
         // und die Generierung käme nicht bis zu den Links.
         await expect(page.locator("#uebung-links")).toBeVisible();
+
+        // Beleg, dass der Mock gegriffen hat: die Übung liegt im lokalen Speicher.
+        // Ohne diese Probe würde ein Abrutschen auf die echte Datenbank lokal
+        // wieder unbemerkt bleiben und erst den Deploy zerlegen.
+        const imMock = await page.evaluate(() =>
+            Object.keys(JSON.parse(window.localStorage.getItem("e2eFirestoreSeed") ?? "{}")).length);
+        expect(imMock, "Übung wurde nicht im Firestore-Mock gespeichert").toBeGreaterThan(0);
         await expect(
             page.locator("#links-teilnehmer-container .generator-link-row[data-link-type='teilnehmer']")
         ).toHaveCount(anzahlFelder);


### PR DESCRIPTION
## Warum

Der Deploy nach GitHub Pages ist **seit AP-08 (#74) bei jedem Lauf rot**. Der
letzte erfolgreiche Deploy war am 04.08. um 08:16 – die Website zeigt seither
keine der Änderungen aus AP-08 bis AP-12.

Ursache ist ein Test, den ich in AP-08 geschrieben habe:
`e2e/funkspruch-archiv.spec.ts` schaltet als einziger Generator-Test den
Firestore-Mock **nicht** ein, den `app.spec.ts:78-84` für alle anderen per
`addInitScript` setzt.

## Was der Trace zeigt

Aus dem CI-Artefakt des fehlgeschlagenen Laufs:

- **kein einziger Firestore-Aufruf** in `1-trace.network` – nur die eigene
  Seite, Schriften und GoatCounter
- **keine Ausnahme, keine Fehlermeldung** in der Konsole; die einzige Warnung
  ist „Konnte keine perfekte Verteilung finden", also lief die Generierung
- `#uebung-links` bleibt verborgen, bis der Test nach 10 s aufgibt

Erklärung: Lokal greift die committete `src/firebase-config.js` und der Schreib-
vorgang gelingt – der Test hat dabei bei **jedem Lauf eine Übung im
Produktivbestand angelegt**. In CI wird `firebase-config.js` aus
`secrets.FIREBASE_*` erzeugt; dort löst das Versprechen aus `saveUebung` nie
auf, und `startUebung()` kommt nie bis `renderUebungResult()`.

## Warum es niemandem auffiel

`ci.yml` fährt die `seo`-Matrix nicht – die läuft nur in `main.yml` **nach** dem
Merge. Die PR-Prüfungen waren also grün, während der Deploy jedes Mal
übersprungen wurde.

## Änderung

- Firestore-Mock einschalten, wie bei allen anderen Generator-Tests
- Probe, dass die Übung tatsächlich im Mock landet – sonst bliebe ein erneutes
  Abrutschen auf die echte Datenbank wieder unbemerkt
- Verteilung (`% an Alle`, `% an Mehrere`, `% Buchstabieren`) ausdrücklich
  setzen statt aus den Modellvorgaben zu erben, mit Probe auf die daraus
  berechneten versteckten Felder

Nur Testcode, kein Produktivcode.

## Wie geprüft

```
npx playwright test --grep @seo
npm run lint
```

377 E2E-Tests grün, 0 Lint-Fehler. Die neue Probe auf den Mock belegt, dass
kein echter Firestore-Aufruf mehr stattfindet.

## Danach

Nach dem Merge sollte der Deploy erstmals seit AP-08 wieder durchlaufen und
`/funksprueche/`, `/autor/`, `/einbetten/` und die PDFs live gehen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
